### PR TITLE
Implement global exercises

### DIFF
--- a/migrate_to_global_exercises.py
+++ b/migrate_to_global_exercises.py
@@ -1,0 +1,34 @@
+import sqlite3
+
+DB_PATH = 'fitness.db'
+
+# This simple script migrates the old Exercise table (with training_plan_id)
+# to the new global Exercise table with the plan_exercises association table.
+
+def migrate(db_path=DB_PATH):
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+
+    # rename old table if it still has training_plan_id column
+    columns = [row[1] for row in c.execute("PRAGMA table_info(exercise)").fetchall()]
+    if 'training_plan_id' not in columns:
+        print('Database already migrated.')
+        conn.close()
+        return
+
+    c.execute('ALTER TABLE exercise RENAME TO exercise_old;')
+    c.execute('CREATE TABLE exercise (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, description TEXT);')
+    c.execute('CREATE TABLE plan_exercises (training_plan_id INTEGER NOT NULL, exercise_id INTEGER NOT NULL, PRIMARY KEY(training_plan_id, exercise_id));')
+
+    for row in c.execute('SELECT id, name, description, training_plan_id FROM exercise_old;').fetchall():
+        ex_id, name, desc, plan_id = row
+        c.execute('INSERT INTO exercise (id, name, description) VALUES (?, ?, ?);', (ex_id, name, desc))
+        c.execute('INSERT INTO plan_exercises (training_plan_id, exercise_id) VALUES (?, ?);', (plan_id, ex_id))
+
+    conn.commit()
+    c.execute('DROP TABLE exercise_old;')
+    conn.commit()
+    conn.close()
+
+if __name__ == '__main__':
+    migrate()

--- a/templates/add_exercise_to_plan.html
+++ b/templates/add_exercise_to_plan.html
@@ -12,6 +12,15 @@
       <form method="POST">
         {{ form.hidden_tag() }}
         <div class="form-group">
+          <label for="existing_exercise">Vorhandene Übung verwenden</label>
+          <select name="existing_exercise_id" class="form-control">
+            <option value="">-- Neue Übung erstellen --</option>
+            {% for ex in existing_exercises %}
+              <option value="{{ ex.id }}">{{ ex.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="form-group">
           {{ form.name.label }} {{ form.name(class="form-control") }}
         </div>
         <div class="form-group">

--- a/templates/edit_exercise.html
+++ b/templates/edit_exercise.html
@@ -21,7 +21,7 @@
           {{ form.submit(class="btn btn-primary btn-block", value="Speichern") }}
         </div>
       </form>
-      <a href="{{ url_for('training_plan_detail', training_plan_id=exercise.training_plan_id) }}" class="btn btn-secondary btn-block">Zurück</a>
+      <a href="{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}" class="btn btn-secondary btn-block">Zurück</a>
     </div>
   </body>
 </html>

--- a/templates/exercise_detail.html
+++ b/templates/exercise_detail.html
@@ -36,7 +36,7 @@
       <form action="{{ url_for('delete_exercise', exercise_id=exercise.id) }}" method="POST" class="mt-4" onsubmit="return confirm('Übung wirklich löschen?');">
         <button type="submit" class="btn btn-danger btn-block">Übung löschen</button>
       </form>
-      <a href="{{ url_for('training_plan_detail', training_plan_id=exercise.training_plan_id) }}" class="btn btn-secondary btn-block mt-2">Zurück</a>
+      <a href="{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}" class="btn btn-secondary btn-block mt-2">Zurück</a>
     </div>
     <script>
       const allSessions = {{ all_sessions|tojson }};


### PR DESCRIPTION
## Summary
- create global `Exercise` table without plan id
- add many-to-many `plan_exercises` association
- adapt routes to use global exercises
- update templates for new workflow
- include migration script for existing data

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684379c4eb948322813a520c4998f293