### PR TITLE
Implement robust offline mode

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -23,4 +23,3 @@ function saveOfflineSession(sessionData) {
       .catch(err => console.error('Sync failed', err));
     }
   });
-  

--- a/static/offline.html
+++ b/static/offline.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Offline</title>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+</head>
+<body class="text-center mt-5">
+  <h1>Du bist offline</h1>
+  <p>Die Anwendung ist derzeit ohne Internetverbindung nutzbar. Sobald eine Verbindung besteht, werden deine Daten synchronisiert.</p>
+</body>
+</html>

--- a/templates/add_session.html
+++ b/templates/add_session.html
@@ -23,5 +23,21 @@
       </form>
       <a href="{{ url_for('exercise_detail', exercise_id=exercise.id) }}" class="btn btn-secondary btn-block">Zurück</a>
     </div>
+    <script src="/static/js/main.js"></script>
+    <script>
+      document.querySelector('form').addEventListener('submit', function(e) {
+        if (!navigator.onLine) {
+          e.preventDefault();
+          saveOfflineSession({
+            exercise_id: {{ exercise.id }},
+            repetitions: document.getElementById('repetitions').value,
+            weight: document.getElementById('weight').value,
+            timestamp: new Date().toISOString()
+          });
+          alert('Offline: Session wird gespeichert und beim n\u00e4chsten Online-Sein synchronisiert.');
+          window.location.href = "{{ url_for('exercise_detail', exercise_id=exercise.id) }}";
+        }
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- improve service worker with network timeout and offline fallback
- cache a new `offline.html` page
- sync offline sessions from `add_session` even without connectivity

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68437fb449c883229e3b3e02506ad126