### PR TITLE
Add CSRF-protected action forms

### DIFF
--- a/templates/admin_overview.html
+++ b/templates/admin_overview.html
@@ -35,17 +35,20 @@
               <td>
                 {% if not user.is_trainer %}
                 <form action="{{ url_for('admin_set_trainer', user_id=user.id) }}" method="POST" style="display:inline;">
-                  <button type="submit" class="btn btn-secondary btn-sm">Trainer setzen</button>
+                  {{ set_trainer_form.hidden_tag() }}
+                  {{ set_trainer_form.submit(class="btn btn-secondary btn-sm", value='Trainer setzen') }}
                 </form>
                 {% else %}
                 <form action="{{ url_for('admin_remove_trainer', user_id=user.id) }}" method="POST" style="display:inline;">
-                  <button type="submit" class="btn btn-secondary btn-sm">Trainer entfernen</button>
+                  {{ remove_trainer_form.hidden_tag() }}
+                  {{ remove_trainer_form.submit(class="btn btn-secondary btn-sm", value='Trainer entfernen') }}
                 </form>
                 {% endif %}
                 <a href="{{ url_for('admin_change_password', user_id=user.id) }}" class="btn btn-primary btn-sm">Passwort ändern</a>
                 {% if user.id != current_user.id %}
                   <form action="{{ url_for('admin_delete_user', user_id=user.id) }}" method="POST" style="display:inline;" onsubmit="return confirm('Benutzer wirklich löschen?');">
-                    <button type="submit" class="btn btn-danger btn-sm">Löschen</button>
+                    {{ delete_user_form.hidden_tag() }}
+                    {{ delete_user_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
                   </form>
                 {% endif %}
               </td>

--- a/templates/admin_template_plans.html
+++ b/templates/admin_template_plans.html
@@ -31,12 +31,16 @@
               <a href="{{ url_for('add_exercise_to_template', template_plan_id=tpl.id) }}" class="btn btn-primary btn-sm">Übung hinzufügen</a>
               <a href="{{ url_for('edit_template_plan', template_plan_id=tpl.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
               <form action="{{ url_for('toggle_template_visibility', template_plan_id=tpl.id) }}" method="POST" style="display:inline;">
-                <button type="submit" class="btn btn-warning btn-sm">
-                  {% if tpl.is_visible %}Unsichtbar{% else %}Sichtbar{% endif %}
-                </button>
+                {{ toggle_form.hidden_tag() }}
+                {% if tpl.is_visible %}
+                {{ toggle_form.submit(class="btn btn-warning btn-sm", value='Unsichtbar') }}
+                {% else %}
+                {{ toggle_form.submit(class="btn btn-warning btn-sm", value='Sichtbar') }}
+                {% endif %}
               </form>
               <form action="{{ url_for('delete_template_plan', template_plan_id=tpl.id) }}" method="POST" style="display:inline;" onsubmit="return confirm('Template Trainingsplan wirklich löschen?');">
-                <button type="submit" class="btn btn-danger btn-sm">Löschen</button>
+                {{ delete_tpl_form.hidden_tag() }}
+                {{ delete_tpl_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
               </form>
             </td>
           </tr>

--- a/templates/exercise_detail.html
+++ b/templates/exercise_detail.html
@@ -27,14 +27,16 @@
           <li class="list-group-item d-flex justify-content-between align-items-center">
             <span>{{ session.timestamp.strftime('%d.%m.%Y %H:%M') }} - {{ session.weight }} kg - {{ session.repetitions }} Wiederholungen</span>
             <form action="{{ url_for('delete_session', session_id=session.id) }}" method="POST" onsubmit="return confirm('Satz wirklich löschen?');">
-              <button type="submit" class="btn btn-danger btn-sm">×</button>
+              {{ delete_session_form.hidden_tag() }}
+              {{ delete_session_form.submit(class="btn btn-danger btn-sm", value="×") }}
             </form>
           </li>
         {% endfor %}
       </ul>
       <form action="{{ url_for('delete_exercise', exercise_id=exercise.id) }}" method="POST" class="mt-4" onsubmit="return confirm('Übung wirklich löschen?');">
+        {{ delete_exercise_form.hidden_tag() }}
         <a href="{{ url_for('edit_exercise', exercise_id=exercise.id) }}" class="btn btn-info btn-block mb-4">Übung bearbeiten</a>
-        <button type="submit" class="btn btn-danger btn-block">Übung löschen</button>
+        {{ delete_exercise_form.submit(class="btn btn-danger btn-block", value='Übung löschen') }}
       </form>
       <a href="{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}" class="btn btn-secondary btn-block mt-2">Zurück</a>
     </div>

--- a/templates/training_plan_detail.html
+++ b/templates/training_plan_detail.html
@@ -14,7 +14,8 @@
       <div class="d-flex justify-content-between align-items-center">
         <h2>{{ training_plan.title }}</h2>
         <form action="{{ url_for('delete_training_plan', training_plan_id=training_plan.id) }}" method="POST" onsubmit="return confirm('Trainingsplan wirklich löschen?');">
-          <button type="submit" class="btn btn-danger btn-sm">Löschen</button>
+          {{ delete_plan_form.hidden_tag() }}
+          {{ delete_plan_form.submit(class="btn btn-danger btn-sm") }}
         </form>
       </div>
       <p>{{ training_plan.description }}</p>


### PR DESCRIPTION
## Summary
- add simple FlaskForm classes for delete/toggle actions
- use these forms in views and templates so CSRF tokens are rendered
- validate these forms in the relevant routes

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6844da286fbc8322936873401d85a173