### PR TITLE
Restrict editing of shared exercises

### DIFF
--- a/templates/exercise_detail.html
+++ b/templates/exercise_detail.html
@@ -35,7 +35,11 @@
       </ul>
       <form action="{{ url_for('delete_exercise', exercise_id=exercise.id) }}" method="POST" class="mt-4" onsubmit="return confirm('Übung wirklich löschen?');">
         {{ delete_exercise_form.hidden_tag() }}
-        <a href="{{ url_for('edit_exercise', exercise_id=exercise.id) }}" class="btn btn-info btn-block mb-4">Übung bearbeiten</a>
+        {% if editable %}
+          <a href="{{ url_for('edit_exercise', exercise_id=exercise.id) }}" class="btn btn-info btn-block mb-4">Übung bearbeiten</a>
+        {% else %}
+          <div class="alert alert-warning">Diese Übung kann nicht bearbeitet werden.</div>
+        {% endif %}
         {{ delete_exercise_form.submit(class="btn btn-danger btn-block", value='Übung löschen') }}
       </form>
       <a href="{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}" class="btn btn-secondary btn-block mt-2">Zurück</a>

--- a/templates/training_plan_detail.html
+++ b/templates/training_plan_detail.html
@@ -33,7 +33,11 @@
               </div>
               <div>
                 <a href="{{ url_for('exercise_detail', exercise_id=exercise.id) }}" class="btn btn-info btn-sm mr-1">Details</a>
-                <a href="{{ url_for('edit_exercise', exercise_id=exercise.id) }}" class="btn btn-secondary btn-sm">Bearbeiten</a>
+                {% if editable_map[exercise.id] %}
+                  <a href="{{ url_for('edit_exercise', exercise_id=exercise.id) }}" class="btn btn-secondary btn-sm">Bearbeiten</a>
+                {% else %}
+                  <span class="text-muted small">Bearbeiten gesperrt</span>
+                {% endif %}
               </div>
             </div>
             <div class="session-list mt-2">


### PR DESCRIPTION
## Summary
- add helper to detect if an exercise is shared
- disable edit links for shared exercises
- block editing in the route when an exercise is used by other users

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6844e1384ac08322bf56b896fe43c291