### PR TITLE
Set /fit as start path

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,7 +1,7 @@
 {
     "short_name": "FitnessApp",
     "name": "Offline Fitness App",
-    "start_url": "/",
+    "start_url": "/fit",
     "display": "standalone",
     "background_color": "#ffffff",
     "theme_color": "#007bff",

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,6 +1,6 @@
 const CACHE_NAME = 'fitness-app-cache-v2';
 const STATIC_ASSETS = [
-  '/',
+  '/fit',
   '/static/manifest.json',
   '/static/js/main.js',
   '/static/offline.html'


### PR DESCRIPTION
## Summary
- keep `/fit` as entrypoint by removing unused root route
- update PWA config to start from `/fit`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6844e5d0958c8322ab0f7485b8558b02