### PR TITLE
Add configurable footer links

### DIFF
--- a/templates/admin_footer_links.html
+++ b/templates/admin_footer_links.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Admin – Footer Links</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div class="container mt-4">
+      <h2>Footer Links verwalten</h2>
+      <form method="POST" class="mb-3">
+        {{ form.hidden_tag() }}
+        <div class="form-row">
+          <div class="col">
+            {{ form.title.label }} {{ form.title(class="form-control") }}
+          </div>
+          <div class="col">
+            {{ form.url.label }} {{ form.url(class="form-control") }}
+          </div>
+          <div class="col-auto">
+            {{ form.submit(class="btn btn-primary mt-4") }}
+          </div>
+        </div>
+      </form>
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Text</th>
+            <th>URL</th>
+            <th>Aktionen</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for link in links %}
+          <tr>
+            <td>{{ link.title }}</td>
+            <td>{{ link.url }}</td>
+            <td>
+              <a href="{{ url_for('edit_footer_link', link_id=link.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
+              <form action="{{ url_for('delete_footer_link', link_id=link.id) }}" method="POST" style="display:inline;">
+                {{ delete_form.hidden_tag() }}
+                {{ delete_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
+              </form>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <a href="{{ url_for('admin_overview') }}" class="btn btn-secondary btn-block">Zurück</a>
+    </div>
+  </body>
+</html>
+

--- a/templates/admin_overview.html
+++ b/templates/admin_overview.html
@@ -9,6 +9,7 @@
   <body>
     <div class="container mt-4">
       <h2>Admin – Benutzerübersicht</h2>
+      <a href="{{ url_for('admin_footer_links') }}" class="btn btn-info mb-3 btn-block">Footer Links verwalten</a>
       <table class="table table-striped">
         <thead>
           <tr>

--- a/templates/edit_footer_link.html
+++ b/templates/edit_footer_link.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Footer Link bearbeiten</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div class="container mt-4">
+      <h2>Footer Link bearbeiten</h2>
+      <form method="POST">
+        {{ form.hidden_tag() }}
+        <div class="form-group">
+          {{ form.title.label }} {{ form.title(class="form-control") }}
+        </div>
+        <div class="form-group">
+          {{ form.url.label }} {{ form.url(class="form-control") }}
+        </div>
+        <div class="form-group">
+          {{ form.submit(class="btn btn-primary btn-block") }}
+        </div>
+      </form>
+      <a href="{{ url_for('admin_footer_links') }}" class="btn btn-secondary btn-block">Zurück</a>
+    </div>
+  </body>
+</html>
+

--- a/templates/login.html
+++ b/templates/login.html
@@ -27,5 +27,10 @@
       </form>
       <p>Noch nicht registriert? <a href="{{ url_for('register') }}">Registrieren</a></p>
     </div>
+    <footer class="bg-light text-center py-2 fixed-bottom">
+      {% for link in footer_links %}
+        <a href="{{ link.url }}" class="mx-2">{{ link.title }}</a>
+      {% endfor %}
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add `FooterLink` model and forms
- implement admin pages to manage footer links
- show footer links on login page
- link footer management from admin overview

## Testing
- `python -m py_compile app.py migrate_to_global_exercises.py`

------
https://chatgpt.com/codex/tasks/task_e_6845a4766f2083229112bc93b82e11e6