### PR TITLE
Add configurable markdown footer pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,9 @@
 from flask import Flask, render_template, redirect, url_for, flash, request, abort, jsonify
+import markdown
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager, UserMixin, login_user, login_required, logout_user, current_user
 from flask_wtf import FlaskForm, RecaptchaField
-from wtforms import StringField, PasswordField, SubmitField, IntegerField, BooleanField
+from wtforms import StringField, PasswordField, SubmitField, IntegerField, BooleanField, TextAreaField
 from wtforms.validators import DataRequired, InputRequired, Length, EqualTo, ValidationError
 from werkzeug.security import generate_password_hash, check_password_hash
 import datetime
@@ -80,6 +81,12 @@ class TemplateExercise(db.Model):
     name = db.Column(db.String(150), nullable=False)
     description = db.Column(db.String(300), nullable=True)  # Beschreibung bei Template-Übung
     template_plan_id = db.Column(db.Integer, db.ForeignKey('template_training_plan.id'), nullable=False)
+
+# Seiten, die im Login-Footer verlinkt werden
+class FooterPage(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(150), nullable=False)
+    content = db.Column(db.Text, nullable=False)
 
 @login_manager.user_loader
 def load_user(user_id):
@@ -189,6 +196,14 @@ class ToggleTemplateVisibilityForm(FlaskForm):
 class DeleteTemplatePlanForm(FlaskForm):
     submit = SubmitField('Löschen')
 
+class FooterPageForm(FlaskForm):
+    title = StringField('Seitentitel', validators=[DataRequired()])
+    content = TextAreaField('Inhalt (Markdown)', validators=[DataRequired()])
+    submit = SubmitField('Speichern')
+
+class DeleteFooterPageForm(FlaskForm):
+    submit = SubmitField('Löschen')
+
 # ----------------------------------------------------
 # Routen
 # ----------------------------------------------------
@@ -226,7 +241,8 @@ def login():
             return redirect(url_for('dashboard'))
         else:
             flash('Ungültiger Benutzername oder Passwort.', 'danger')
-    return render_template('login.html', form=form)
+    pages = FooterPage.query.all()
+    return render_template('login.html', form=form, footer_pages=pages)
 
 @app.route('/logout')
 @login_required
@@ -539,6 +555,57 @@ def admin_remove_trainer(user_id):
         flash(f"Trainer-Rang wurde von {user.username} entfernt.", "success")
         return redirect(url_for('admin_overview'))
     abort(400)
+
+# ----------------------------------------------------
+# Footer-Seiten verwalten
+# ----------------------------------------------------
+@app.route('/admin/footer_pages', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def admin_footer_pages():
+    form = FooterPageForm()
+    delete_form = DeleteFooterPageForm()
+    if form.validate_on_submit():
+        new_page = FooterPage(title=form.title.data, content=form.content.data)
+        db.session.add(new_page)
+        db.session.commit()
+        flash('Seite hinzugefügt!', 'success')
+        return redirect(url_for('admin_footer_pages'))
+    pages = FooterPage.query.all()
+    return render_template('admin_footer_pages.html', pages=pages, form=form, delete_form=delete_form)
+
+@app.route('/admin/footer_page/<int:page_id>/edit', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def edit_footer_page(page_id):
+    page = FooterPage.query.get_or_404(page_id)
+    form = FooterPageForm(obj=page)
+    if form.validate_on_submit():
+        page.title = form.title.data
+        page.content = form.content.data
+        db.session.commit()
+        flash('Seite aktualisiert!', 'success')
+        return redirect(url_for('admin_footer_pages'))
+    return render_template('edit_footer_page.html', form=form, page=page)
+
+@app.route('/admin/footer_page/<int:page_id>/delete', methods=['POST'])
+@login_required
+@admin_required
+def delete_footer_page(page_id):
+    page = FooterPage.query.get_or_404(page_id)
+    form = DeleteFooterPageForm()
+    if form.validate_on_submit():
+        db.session.delete(page)
+        db.session.commit()
+        flash('Seite gelöscht!', 'info')
+        return redirect(url_for('admin_footer_pages'))
+    abort(400)
+
+@app.route('/page/<int:page_id>')
+def view_footer_page(page_id):
+    page = FooterPage.query.get_or_404(page_id)
+    html = markdown.markdown(page.content)
+    return render_template('footer_page.html', page=page, html_content=html)
 
 # ----------------------------------------------------
 # Admin-/Trainer-Funktionalitäten für Template-Pläne

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask_SQLAlchemy
 Flask_Login
 Flask_WTF
 WTForms
+markdown

--- a/templates/admin_footer_pages.html
+++ b/templates/admin_footer_pages.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Admin – Footer-Seiten</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div class="container mt-4">
+      <h2>Footer-Seiten verwalten</h2>
+      <form method="POST" class="mb-3">
+        {{ form.hidden_tag() }}
+        <div class="form-row">
+          <div class="col">
+            {{ form.title.label }} {{ form.title(class="form-control") }}
+          </div>
+          <div class="col">
+            {{ form.content.label }} {{ form.content(class="form-control", rows=4) }}
+          </div>
+          <div class="col-auto">
+            {{ form.submit(class="btn btn-primary mt-4") }}
+          </div>
+        </div>
+      </form>
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Text</th>
+            <th>Vorschau</th>
+            <th>Aktionen</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for page in pages %}
+          <tr>
+            <td>{{ page.title }}</td>
+            <td>{{ page.content[:30] }}{% if page.content|length > 30 %}...{% endif %}</td>
+            <td>
+              <a href="{{ url_for('edit_footer_page', page_id=page.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
+              <form action="{{ url_for('delete_footer_page', page_id=page.id) }}" method="POST" style="display:inline;">
+                {{ delete_form.hidden_tag() }}
+                {{ delete_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
+              </form>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <a href="{{ url_for('admin_overview') }}" class="btn btn-secondary btn-block">Zurück</a>
+    </div>
+  </body>
+</html>
+

--- a/templates/admin_overview.html
+++ b/templates/admin_overview.html
@@ -9,6 +9,7 @@
   <body>
     <div class="container mt-4">
       <h2>Admin – Benutzerübersicht</h2>
+      <a href="{{ url_for('admin_footer_pages') }}" class="btn btn-info mb-3 btn-block">Footer-Seiten verwalten</a>
       <table class="table table-striped">
         <thead>
           <tr>

--- a/templates/edit_footer_page.html
+++ b/templates/edit_footer_page.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Footer-Seite bearbeiten</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div class="container mt-4">
+      <h2>Footer-Seite bearbeiten</h2>
+      <form method="POST">
+        {{ form.hidden_tag() }}
+        <div class="form-group">
+          {{ form.title.label }} {{ form.title(class="form-control") }}
+        </div>
+        <div class="form-group">
+          {{ form.content.label }} {{ form.content(class="form-control", rows=8) }}
+        </div>
+        <div class="form-group">
+          {{ form.submit(class="btn btn-primary btn-block") }}
+        </div>
+      </form>
+      <a href="{{ url_for('admin_footer_pages') }}" class="btn btn-secondary btn-block">Zurück</a>
+    </div>
+  </body>
+</html>
+

--- a/templates/footer_page.html
+++ b/templates/footer_page.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>{{ page.title }}</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div class="container mt-4">
+      <h2>{{ page.title }}</h2>
+      <div class="mt-3">
+        {{ html_content|safe }}
+      </div>
+      <a href="{{ url_for('login') }}" class="btn btn-secondary mt-4">Zurück</a>
+    </div>
+  </body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -27,5 +27,10 @@
       </form>
       <p>Noch nicht registriert? <a href="{{ url_for('register') }}">Registrieren</a></p>
     </div>
+    <footer class="bg-light text-center py-2 fixed-bottom">
+      {% for page in footer_pages %}
+        <a href="{{ url_for('view_footer_page', page_id=page.id) }}" class="mx-2">{{ page.title }}</a>
+      {% endfor %}
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace footer link model with markdown-based `FooterPage`
- add admin interface to create, edit and delete footer pages
- show footer pages on login page and render content with Markdown
- include a back button on each footer page

## Testing
- `python -m py_compile app.py migrate_to_global_exercises.py`


------
https://chatgpt.com/codex/tasks/task_e_6845a4766f2083229112bc93b82e11e6