### PR TITLE
Improve countdown timer with wake lock

### DIFF
--- a/templates/add_session.html
+++ b/templates/add_session.html
@@ -74,6 +74,24 @@
         const overlay = document.getElementById('restOverlay');
         const progressCircle = document.getElementById('progressCircle');
         const timerText = document.getElementById('timerText');
+        let wakeLock = null;
+
+        async function requestWakeLock() {
+          if ('wakeLock' in navigator) {
+            try {
+              wakeLock = await navigator.wakeLock.request('screen');
+            } catch (err) {
+              console.error('Wake Lock error:', err);
+            }
+          }
+        }
+
+        function releaseWakeLock() {
+          if (wakeLock) {
+            wakeLock.release();
+            wakeLock = null;
+          }
+        }
 
         document.getElementById('startRest').addEventListener('click', function() {
         const input = document.getElementById('restTime');
@@ -103,12 +121,15 @@
             timerText.textContent = formatTime(sec);
             progressCircle.style.strokeDashoffset = circumference * (1 - sec / total);
           }
+          const endTime = Date.now() + remaining * 1000;
           updateDisplay(remaining);
-          const interval = setInterval(function() {
-            remaining--;
-            updateDisplay(remaining);
+          requestWakeLock();
+          const interval = setInterval(() => {
+            remaining = Math.ceil((endTime - Date.now()) / 1000);
+            updateDisplay(Math.max(remaining, 0));
             if (remaining <= 0) {
               clearInterval(interval);
+              releaseWakeLock();
               window.location.href = "{{ url_for('exercise_detail', exercise_id=exercise.id) }}";
             }
           }, 1000);


### PR DESCRIPTION
## Summary
- keep the screen awake during the rest countdown
- calculate remaining time based on end time so timer stays accurate

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_687ae0fef68883229f40ab37446baaf0