### PR TITLE
Add notes and RPE fields to exercise sessions

### DIFF
--- a/migrate_add_session_notes_rpe.py
+++ b/migrate_add_session_notes_rpe.py
@@ -1,0 +1,29 @@
+import sqlite3
+
+DB_PATH = 'fitness.db'
+
+
+def migrate(db_path=DB_PATH):
+    """Add notes and perceived_exertion columns to exercise_session if missing."""
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        columns = [row[1] for row in cursor.execute("PRAGMA table_info(exercise_session)").fetchall()]
+        added = False
+        if 'notes' not in columns:
+            cursor.execute('ALTER TABLE exercise_session ADD COLUMN notes TEXT;')
+            added = True
+        if 'perceived_exertion' not in columns:
+            cursor.execute('ALTER TABLE exercise_session ADD COLUMN perceived_exertion INTEGER;')
+            added = True
+        conn.commit()
+        if added:
+            print('Migration completed: columns added.')
+        else:
+            print('Database already up to date.')
+    finally:
+        conn.close()
+
+
+if __name__ == '__main__':
+    migrate()

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,13 +1,25 @@
 // Speichert offline erstellte Sessions in LocalStorage
 function saveOfflineSession(sessionData) {
     let offlineSessions = JSON.parse(localStorage.getItem('offlineSessions')) || [];
-    offlineSessions.push(sessionData);
+    const normalizedSession = { ...sessionData };
+    if (normalizedSession.notes === undefined) {
+      normalizedSession.notes = null;
+    }
+    if (normalizedSession.perceived_exertion === undefined) {
+      normalizedSession.perceived_exertion = null;
+    }
+    offlineSessions.push(normalizedSession);
     localStorage.setItem('offlineSessions', JSON.stringify(offlineSessions));
   }
   
   // Synchronisation beim Online-Gehen
   window.addEventListener('online', function() {
     let offlineSessions = JSON.parse(localStorage.getItem('offlineSessions')) || [];
+    offlineSessions = offlineSessions.map(session => ({
+      ...session,
+      notes: session.notes ?? null,
+      perceived_exertion: session.perceived_exertion ?? null,
+    }));
     if (offlineSessions.length > 0) {
       fetch('/sync', {
         method: 'POST',

--- a/templates/add_session.html
+++ b/templates/add_session.html
@@ -18,6 +18,12 @@
           {{ form.weight.label }} {{ form.weight(class="form-control", pattern="\d*") }}
         </div>
         <div class="form-group">
+          {{ form.perceived_exertion.label }} {{ form.perceived_exertion(class="form-control", pattern="\d*") }}
+        </div>
+        <div class="form-group">
+          {{ form.notes.label }} {{ form.notes(class="form-control") }}
+        </div>
+        <div class="form-group">
           {{ form.submit(class="btn btn-primary btn-block") }}
         </div>
       </form>
@@ -54,10 +60,15 @@
         document.querySelector('form').addEventListener('submit', function(e) {
         if (!navigator.onLine) {
           e.preventDefault();
+          const rpeValue = document.getElementById('perceived_exertion').value;
+          const parsedRpe = rpeValue ? parseInt(rpeValue, 10) : null;
+          const normalizedRpe = Number.isNaN(parsedRpe) ? null : parsedRpe;
           saveOfflineSession({
             exercise_id: {{ exercise.id }},
             repetitions: document.getElementById('repetitions').value,
             weight: document.getElementById('weight').value,
+            perceived_exertion: normalizedRpe,
+            notes: document.getElementById('notes').value || null,
             timestamp: new Date().toISOString()
           });
           alert('Offline: Session wird gespeichert und beim n\u00e4chsten Online-Sein synchronisiert.');
@@ -99,6 +110,10 @@
         if (remaining <= 0) { return; }
         const reps = document.getElementById('repetitions').value;
         const weight = document.getElementById('weight').value;
+        const notes = document.getElementById('notes').value;
+        const rpeRaw = document.getElementById('perceived_exertion').value;
+        const parsedRpe = rpeRaw ? parseInt(rpeRaw, 10) : null;
+        const normalizedRpe = Number.isNaN(parsedRpe) ? null : parsedRpe;
         if (!reps || !weight) {
           alert('Bitte Wiederholungen und Gewicht eingeben.');
           return;
@@ -107,7 +122,9 @@
 
         const sessionData = {
           repetitions: reps,
-          weight: weight
+          weight: weight,
+          notes: notes || null,
+          perceived_exertion: normalizedRpe
         };
 
         function startCountdown() {
@@ -148,6 +165,8 @@
             exercise_id: {{ exercise.id }},
             repetitions: reps,
             weight: weight,
+            notes: notes || null,
+            perceived_exertion: normalizedRpe,
             timestamp: new Date().toISOString()
           });
           startCountdown();

--- a/templates/exercise_detail.html
+++ b/templates/exercise_detail.html
@@ -25,7 +25,19 @@
       <ul class="list-group">
         {% for session in sessions %}
           <li class="list-group-item d-flex justify-content-between align-items-center">
-            <span>{{ session.timestamp.strftime('%d.%m.%Y %H:%M') }} - {{ session.weight }} kg - {{ session.repetitions }} Wiederholungen</span>
+            <div>
+              <div>{{ session.timestamp.strftime('%d.%m.%Y %H:%M') }} - {{ session.weight }} kg - {{ session.repetitions }} Wiederholungen</div>
+              {% if session.perceived_exertion is not none or session.notes %}
+                <div class="mt-1 small text-muted">
+                  {% if session.perceived_exertion is not none %}
+                    <div>RPE: {{ session.perceived_exertion }}</div>
+                  {% endif %}
+                  {% if session.notes %}
+                    <div>Notizen: {{ session.notes.replace('\n', '<br>')|safe }}</div>
+                  {% endif %}
+                </div>
+              {% endif %}
+            </div>
             <form action="{{ url_for('delete_session', session_id=session.id) }}" method="POST" onsubmit="return confirm('Satz wirklich löschen?');">
               {{ delete_session_form.hidden_tag() }}
               {{ delete_session_form.submit(class="btn btn-danger btn-sm", value="×") }}
@@ -49,6 +61,8 @@
       const labels = allSessions.map(s => s.timestamp);
       const weights = allSessions.map(s => s.weight);
       const repetitions = allSessions.map(s => s.repetitions);
+      const notes = allSessions.map(s => s.notes || '');
+      const perceivedExertion = allSessions.map(s => s.perceived_exertion);
       const ctx = document.getElementById('progressChart').getContext('2d');
       const progressChart = new Chart(ctx, {
         type: 'line',
@@ -76,6 +90,25 @@
         options: {
           responsive: true,
           maintainAspectRatio: false,
+          plugins: {
+            tooltip: {
+              callbacks: {
+                afterBody: function(context) {
+                  const index = context[0].dataIndex;
+                  const details = [];
+                  const rpeValue = perceivedExertion[index];
+                  const noteValue = notes[index];
+                  if (rpeValue !== null && rpeValue !== undefined) {
+                    details.push('RPE: ' + rpeValue);
+                  }
+                  if (noteValue) {
+                    details.push('Notizen: ' + noteValue);
+                  }
+                  return details;
+                }
+              }
+            }
+          },
           scales: {
             x: {
               title: { display: true, text: 'Datum und Uhrzeit' }


### PR DESCRIPTION
## Summary
- add notes and perceived exertion columns to exercise sessions with a lightweight SQLite migration
- extend the session form, offline workflow, and templates to capture notes/RPE and prefill the last values
- expose the new data through sync and API responses and surface it in the exercise detail chart and list

## Testing
- python -m compileall app.py static/js/main.js templates/add_session.html templates/exercise_detail.html migrate_add_session_notes_rpe.py

------
https://chatgpt.com/codex/tasks/task_e_68e0648747f48322921a6a0a47c08431