### PR TITLE
Enhance exercise analytics and plan summaries

### DIFF
--- a/templates/exercise_detail.html
+++ b/templates/exercise_detail.html
@@ -17,6 +17,52 @@
       {% if exercise.description %}
         <p class="text-center text-muted">{{ exercise.description }}</p>
       {% endif %}
+      {% if summary_metrics.total_sessions %}
+        <div class="row text-center mb-4">
+          <div class="col-sm-6 col-lg-3 mb-3">
+            <div class="card shadow-sm h-100">
+              <div class="card-body">
+                <h6 class="text-uppercase text-muted">Gesamtvolumen</h6>
+                <h4 class="mb-1">{{ summary_metrics.total_volume|round(1) }} kg</h4>
+                <div class="small text-muted">{{ summary_metrics.total_sessions }} Sätze insgesamt</div>
+                <div class="small text-muted">Gleitender Ø ({{ moving_window }}): {{ summary_metrics.recent_volume_average|round(1) }} kg</div>
+                <div class="small text-muted">Bester Satz: {{ personal_bests.max_volume.value }} kg am {{ personal_bests.max_volume.timestamp.strftime('%d.%m.%Y') }}</div>
+              </div>
+            </div>
+          </div>
+          <div class="col-sm-6 col-lg-3 mb-3">
+            <div class="card shadow-sm h-100">
+              <div class="card-body">
+                <h6 class="text-uppercase text-muted">Letzte Einheit</h6>
+                <h5 class="mb-1">{{ summary_metrics.latest_session.weight }} kg × {{ summary_metrics.latest_session.repetitions }}</h5>
+                <div class="small text-muted">{{ summary_metrics.latest_session.timestamp.strftime('%d.%m.%Y %H:%M') }}</div>
+              </div>
+            </div>
+          </div>
+          <div class="col-sm-6 col-lg-3 mb-3">
+            <div class="card shadow-sm h-100">
+              <div class="card-body">
+                <h6 class="text-uppercase text-muted">Max. Gewicht</h6>
+                <h4 class="mb-1">{{ personal_bests.max_weight.value }} kg</h4>
+                <div class="small text-muted">{{ personal_bests.max_weight.repetitions }} Wdh · {{ personal_bests.max_weight.timestamp.strftime('%d.%m.%Y') }}</div>
+                <div class="small text-muted">Volumen: {{ personal_bests.max_volume.value }} kg</div>
+              </div>
+            </div>
+          </div>
+          <div class="col-sm-6 col-lg-3 mb-3">
+            <div class="card shadow-sm h-100">
+              <div class="card-body">
+                <h6 class="text-uppercase text-muted">Beste 1RM (Epley)</h6>
+                <h4 class="mb-1">{{ personal_bests.max_one_rm.value|round(1) }} kg</h4>
+                <div class="small text-muted">{{ personal_bests.max_one_rm.weight }} kg × {{ personal_bests.max_one_rm.repetitions }} Wdh</div>
+                <div class="small text-muted">Gleitender Ø ({{ moving_window }}): {{ summary_metrics.recent_one_rm_average|round(1) }} kg</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      {% else %}
+        <div class="alert alert-info">Für diese Übung wurden noch keine Trainingseinheiten erfasst.</div>
+      {% endif %}
       <div id="chartContainer" class="mb-4">
         <canvas id="progressChart"></canvas>
       </div>
@@ -57,12 +103,11 @@
       <a href="{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}" class="btn btn-secondary btn-block mt-2">Zurück</a>
     </div>
     <script>
-      const allSessions = {{ all_sessions|tojson }};
-      const labels = allSessions.map(s => s.timestamp);
-      const weights = allSessions.map(s => s.weight);
-      const repetitions = allSessions.map(s => s.repetitions);
-      const notes = allSessions.map(s => s.notes || '');
-      const perceivedExertion = allSessions.map(s => s.perceived_exertion);
+      const chartData = {{ chart_data|tojson }};
+      const movingWindow = {{ moving_window }};
+      const labels = chartData.labels;
+      const notes = chartData.notes;
+      const perceivedExertion = chartData.perceived_exertion;
       const ctx = document.getElementById('progressChart').getContext('2d');
       const progressChart = new Chart(ctx, {
         type: 'line',
@@ -71,31 +116,80 @@
           datasets: [
             {
               label: 'Gewicht (kg)',
-              data: weights,
+              data: chartData.weights,
               borderColor: 'rgba(75, 192, 192, 1)',
               backgroundColor: 'rgba(75, 192, 192, 0.2)',
               fill: false,
-              tension: 0.1
+              tension: 0.1,
+              yAxisID: 'yWeight'
             },
             {
               label: 'Wiederholungen',
-              data: repetitions,
+              data: chartData.repetitions,
               borderColor: 'rgba(153, 102, 255, 1)',
               backgroundColor: 'rgba(153, 102, 255, 0.2)',
               fill: false,
-              tension: 0.1
+              tension: 0.1,
+              yAxisID: 'yReps'
+            },
+            {
+              label: 'Volumen (kg)',
+              data: chartData.volume,
+              borderColor: 'rgba(255, 99, 132, 1)',
+              backgroundColor: 'rgba(255, 99, 132, 0.2)',
+              fill: false,
+              tension: 0.1,
+              yAxisID: 'yVolume'
+            },
+            {
+              label: `Volumen gleitender Ø (${movingWindow})`,
+              data: chartData.moving_avg_volume,
+              borderColor: 'rgba(194, 24, 91, 1)',
+              backgroundColor: 'rgba(194, 24, 91, 0.15)',
+              borderDash: [6, 4],
+              fill: false,
+              tension: 0.2,
+              yAxisID: 'yVolume'
+            },
+            {
+              label: '1RM (Epley)',
+              data: chartData.one_rm,
+              borderColor: 'rgba(255, 159, 64, 1)',
+              backgroundColor: 'rgba(255, 159, 64, 0.2)',
+              fill: false,
+              tension: 0.1,
+              yAxisID: 'yWeight'
+            },
+            {
+              label: `1RM gleitender Ø (${movingWindow})`,
+              data: chartData.moving_avg_one_rm,
+              borderColor: 'rgba(255, 205, 86, 1)',
+              backgroundColor: 'rgba(255, 205, 86, 0.15)',
+              borderDash: [4, 4],
+              fill: false,
+              tension: 0.2,
+              yAxisID: 'yWeight'
             }
           ]
         },
         options: {
           responsive: true,
           maintainAspectRatio: false,
+          interaction: { mode: 'index', intersect: false },
           plugins: {
             tooltip: {
               callbacks: {
                 afterBody: function(context) {
                   const index = context[0].dataIndex;
                   const details = [];
+                  const volume = chartData.volume[index];
+                  const oneRm = chartData.one_rm[index];
+                  if (volume !== undefined) {
+                    details.push('Volumen: ' + volume + ' kg');
+                  }
+                  if (oneRm !== undefined) {
+                    details.push('1RM (Epley): ' + oneRm.toFixed(1) + ' kg');
+                  }
                   const rpeValue = perceivedExertion[index];
                   const noteValue = notes[index];
                   if (rpeValue !== null && rpeValue !== undefined) {
@@ -113,8 +207,23 @@
             x: {
               title: { display: true, text: 'Datum und Uhrzeit' }
             },
-            y: {
-              title: { display: true, text: 'Wert' },
+            yWeight: {
+              type: 'linear',
+              position: 'left',
+              title: { display: true, text: 'Gewicht / 1RM (kg)' },
+              beginAtZero: true
+            },
+            yVolume: {
+              type: 'linear',
+              position: 'right',
+              title: { display: true, text: 'Volumen (kg)' },
+              beginAtZero: true,
+              grid: { drawOnChartArea: false }
+            },
+            yReps: {
+              type: 'linear',
+              position: 'right',
+              display: false,
               beginAtZero: true
             }
           }

--- a/templates/training_plan_detail.html
+++ b/templates/training_plan_detail.html
@@ -20,32 +20,106 @@
       </div>
       <p>{{ training_plan.description }}</p>
       <a href="{{ url_for('add_exercise_to_plan', training_plan_id=training_plan.id) }}" class="btn btn-success mb-3 btn-block">Übung hinzufügen</a>
-      <h3>Übungen</h3>
-      <ul class="list-group">
-        {% for exercise in training_plan.exercises %}
-          <li class="list-group-item">
-            <div class="d-flex justify-content-between align-items-center">
-              <div>
-                <strong>{{ exercise.name }}</strong>
-                {% if exercise.description %}
-                  <p class="mb-0 small text-muted">{{ exercise.description }}</p>
-                {% endif %}
-              </div>
-              <div>
-                <a href="{{ url_for('exercise_detail', exercise_id=exercise.id) }}" class="btn btn-info btn-sm mr-1">Details</a>
-              </div>
-            </div>
-            <div class="session-list mt-2">
-              {% set sessions_sorted = exercise.sessions|sort(attribute='timestamp', reverse=True) %}
-              {% for session in sessions_sorted[:3] %}
-                <div>
-                  {{ session.timestamp.strftime('%d.%m.%Y %H:%M') }} - {{ session.weight }} kg - {{ session.repetitions }} Wiederholungen
-                </div>
+      {% if exercise_overview %}
+        <h3>Übungsstatistiken</h3>
+        <div class="table-responsive mb-4">
+          <table class="table table-sm table-striped">
+            <thead>
+              <tr>
+                <th>Übung</th>
+                <th class="text-center">Sätze</th>
+                <th>Letzte Einheit</th>
+                <th>Gesamtvolumen</th>
+                <th>Max. Gewicht</th>
+                <th>Beste 1RM (Epley)</th>
+                <th>Ø Volumen ({{ exercise_overview[0].moving_window }}er Ø)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in exercise_overview %}
+                {% set summary = item.summary %}
+                {% set personal_bests = item.personal_bests %}
+                <tr>
+                  <td>
+                    <strong>{{ item.exercise.name }}</strong>
+                    {% if item.exercise.description %}
+                      <div class="small text-muted">{{ item.exercise.description }}</div>
+                    {% endif %}
+                  </td>
+                  <td class="text-center">{{ summary.total_sessions }}</td>
+                  <td>
+                    {% if summary.latest_session %}
+                      {{ summary.latest_session.timestamp.strftime('%d.%m.%Y') }}<br>
+                      <span class="small text-muted">{{ summary.latest_session.weight }} kg × {{ summary.latest_session.repetitions }}</span>
+                    {% else %}
+                      <span class="text-muted">–</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if summary.total_sessions %}
+                      {{ summary.total_volume|round(1) }} kg
+                    {% else %}
+                      <span class="text-muted">–</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if personal_bests.max_weight %}
+                      {{ personal_bests.max_weight.value }} kg
+                      <div class="small text-muted">{{ personal_bests.max_weight.repetitions }} Wdh</div>
+                    {% else %}
+                      <span class="text-muted">–</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if personal_bests.max_one_rm %}
+                      {{ personal_bests.max_one_rm.value|round(1) }} kg
+                      <div class="small text-muted">{{ personal_bests.max_one_rm.weight }} kg × {{ personal_bests.max_one_rm.repetitions }}</div>
+                    {% else %}
+                      <span class="text-muted">–</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if summary.total_sessions %}
+                      {{ summary.recent_volume_average|round(1) }} kg
+                    {% else %}
+                      <span class="text-muted">–</span>
+                    {% endif %}
+                  </td>
+                </tr>
               {% endfor %}
-            </div>
-          </li>
-        {% endfor %}
-      </ul>
+            </tbody>
+          </table>
+        </div>
+        <h3>Übungen</h3>
+        <ul class="list-group">
+          {% for item in exercise_overview %}
+            <li class="list-group-item">
+              <div class="d-flex justify-content-between align-items-center">
+                <div>
+                  <strong>{{ item.exercise.name }}</strong>
+                  {% if item.exercise.description %}
+                    <p class="mb-0 small text-muted">{{ item.exercise.description }}</p>
+                  {% endif %}
+                </div>
+                <div>
+                  <a href="{{ url_for('exercise_detail', exercise_id=item.exercise.id) }}" class="btn btn-info btn-sm mr-1">Details</a>
+                </div>
+              </div>
+              <div class="session-list mt-2">
+                {% for session in item.recent_sessions %}
+                  <div>
+                    {{ session.timestamp.strftime('%d.%m.%Y %H:%M') }} - {{ session.weight }} kg - {{ session.repetitions }} Wiederholungen
+                  </div>
+                {% else %}
+                  <div class="text-muted">Noch keine Einheiten erfasst.</div>
+                {% endfor %}
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <div class="alert alert-info">Füge deinem Trainingsplan eine Übung hinzu, um Auswertungen zu sehen.</div>
+      {% endif %}
       <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block mt-3">Zurück</a>
     </div>
   </body>


### PR DESCRIPTION
## Summary
- add reusable helpers to calculate per-exercise KPIs and expose them in the exercise detail route and API
- expand the exercise detail template with summary cards and richer Chart.js datasets built from the computed metrics
- surface aggregated per-exercise statistics inside the training plan detail view for quick plan-level insights

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e066c7a4308322a4940417e800c356