### PR TITLE
Move training data export links into dropdown

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -26,9 +26,23 @@
         {% endfor %}
       </ul>
       <a href="{{ url_for('template_plans') }}" class="btn btn-info btn-block mt-3">Vorlagen ansehen</a>
+      <div class="dropdown mt-3">
+        <button class="btn btn-outline-primary btn-block dropdown-toggle" type="button" id="dashboardActionsDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Weitere Aktionen
+        </button>
+        <div class="dropdown-menu dropdown-menu-right w-100" aria-labelledby="dashboardActionsDropdown">
+          <h6 class="dropdown-header">Datenexport</h6>
+          <a class="dropdown-item" href="{{ url_for('export_training_data') }}">Trainingsdaten als JSON exportieren</a>
+          <a class="dropdown-item" href="{{ url_for('export_training_data', format='csv') }}">Trainingsdaten als CSV exportieren</a>
+          <div class="dropdown-divider"></div>
+          <span class="dropdown-item-text text-muted small">JSON-Export unterstützt optionale ZIP-Komprimierung über <code>?zip=1</code>.</span>
+        </div>
+      </div>
       {% if current_user.is_admin or current_user.is_trainer %}
         <a href="{{ url_for('admin_template_plans') }}" class="btn btn-warning btn-block mt-3">Template Trainingspläne verwalten</a>
       {% endif %}
     </div>
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-LtrjvnR4/Jkk+1AnsuGukdxbCJO/q9OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,77 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app import (
+    app,
+    db,
+    User,
+    TrainingPlan,
+    Exercise,
+    ExerciseSession,
+    generate_password_hash,
+)
+
+
+@pytest.fixture
+def client():
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI='sqlite:///:memory:',
+        WTF_CSRF_ENABLED=False,
+    )
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        user = User(username='tester', password=generate_password_hash('secret'))
+        db.session.add(user)
+        db.session.commit()
+
+        plan = TrainingPlan(title='Hypertrophy', description='8 Wochen', user_id=user.id)
+        db.session.add(plan)
+        db.session.flush()
+
+        exercise = Exercise(name='Kniebeuge', description='Langhantel')
+        db.session.add(exercise)
+        db.session.flush()
+        plan.exercises.append(exercise)
+        db.session.flush()
+
+        session = ExerciseSession(
+            exercise_id=exercise.id,
+            repetitions=5,
+            weight=100,
+            notes='Saubere Technik',
+            perceived_exertion=8,
+        )
+        db.session.add(session)
+        db.session.commit()
+
+    with app.test_client() as client:
+        response = client.post('/api/login', json={'username': 'tester', 'password': 'secret'})
+        assert response.status_code == 200
+        yield client
+
+
+def test_json_export_contains_expected_structure(client):
+    response = client.get('/export/training-data')
+    assert response.status_code == 200
+    payload = json.loads(response.data)
+    assert payload['format'] == 'json'
+    assert len(payload['training_plans']) == 1
+    plan = payload['training_plans'][0]
+    assert plan['title'] == 'Hypertrophy'
+    assert plan['exercises'][0]['sessions'][0]['weight'] == 100
+
+
+def test_csv_export_returns_rows(client):
+    response = client.get('/export/training-data?format=csv')
+    assert response.status_code == 200
+    body = response.data.decode('utf-8')
+    lines = [line for line in body.splitlines() if line.strip()]
+    assert lines[0].startswith('plan_id')
+    assert any('Hypertrophy' in line for line in lines[1:])


### PR DESCRIPTION
## Summary
- add reusable serialization helpers and a protected export endpoint that streams JSON or CSV with optional ZIP compression
- surface export functionality on the dashboard with clear guidance about JSON and CSV formats
- add automated pytest coverage to verify the export structure and CSV output
- move the dashboard export controls into a dropdown submenu to keep the page layout compact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0696c8394832298a53d82412a6246