### PR TITLE
Handle missing exercise_session table in migration

### DIFF
--- a/migrate_add_session_notes_rpe.py
+++ b/migrate_add_session_notes_rpe.py
@@ -8,6 +8,13 @@ def migrate(db_path=DB_PATH):
     conn = sqlite3.connect(db_path)
     try:
         cursor = conn.cursor()
+        table_exists = cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='exercise_session';"
+        ).fetchone()
+        if not table_exists:
+            print("Table 'exercise_session' does not exist. Skipping migration.")
+            return
+
         columns = [row[1] for row in cursor.execute("PRAGMA table_info(exercise_session)").fetchall()]
         added = False
         if 'notes' not in columns:


### PR DESCRIPTION
## Summary
- guard the session notes migration to skip execution when the exercise_session table is absent
- keep the existing column checks and messaging unchanged for existing databases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0fd81a4088322a78bf74fb0b30b77