### PR TITLE
Add exercise_session table creation to migration script

### DIFF
--- a/migrate_to_global_exercises.py
+++ b/migrate_to_global_exercises.py
@@ -19,6 +19,18 @@ def migrate(db_path=DB_PATH):
     c.execute('ALTER TABLE exercise RENAME TO exercise_old;')
     c.execute('CREATE TABLE exercise (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, description TEXT);')
     c.execute('CREATE TABLE plan_exercises (training_plan_id INTEGER NOT NULL, exercise_id INTEGER NOT NULL, PRIMARY KEY(training_plan_id, exercise_id));')
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS exercise_session (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            exercise_id INTEGER NOT NULL,
+            repetitions INTEGER NOT NULL,
+            weight INTEGER NOT NULL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            notes TEXT,
+            perceived_exertion INTEGER,
+            FOREIGN KEY(exercise_id) REFERENCES exercise(id)
+        );
+    ''')
 
     for row in c.execute('SELECT id, name, description, training_plan_id FROM exercise_old;').fetchall():
         ex_id, name, desc, plan_id = row


### PR DESCRIPTION
## Summary
- extend the migration to create the exercise_session table alongside the other exercise tables
- define all columns, default timestamp, and foreign key to exercise
- guard the new table creation with IF NOT EXISTS so the migration is rerunnable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1047757388322b43cf12319eeb048