### PR TITLE
Harden migration table checks

### DIFF
--- a/migrate_to_global_exercises.py
+++ b/migrate_to_global_exercises.py
@@ -18,7 +18,64 @@ def migrate(db_path=DB_PATH):
 
     c.execute('ALTER TABLE exercise RENAME TO exercise_old;')
     c.execute('CREATE TABLE exercise (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, description TEXT);')
-    c.execute('CREATE TABLE plan_exercises (training_plan_id INTEGER NOT NULL, exercise_id INTEGER NOT NULL, PRIMARY KEY(training_plan_id, exercise_id));')
+
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS plan_exercises (
+            training_plan_id INTEGER NOT NULL,
+            exercise_id INTEGER NOT NULL,
+            PRIMARY KEY(training_plan_id, exercise_id),
+            FOREIGN KEY(training_plan_id) REFERENCES training_plan(id),
+            FOREIGN KEY(exercise_id) REFERENCES exercise(id)
+        );
+    ''')
+
+    plan_exercises_columns = {
+        row[1] for row in c.execute('PRAGMA table_info(plan_exercises);').fetchall()
+    }
+    expected_plan_exercises = {'training_plan_id', 'exercise_id'}
+    if not expected_plan_exercises.issubset(plan_exercises_columns):
+        missing = expected_plan_exercises - plan_exercises_columns
+        raise RuntimeError(
+            f"Existing plan_exercises table missing required columns: {', '.join(sorted(missing))}"
+        )
+
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS exercise_session (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            exercise_id INTEGER NOT NULL,
+            repetitions INTEGER NOT NULL,
+            weight INTEGER NOT NULL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            notes TEXT,
+            perceived_exertion INTEGER,
+            FOREIGN KEY(exercise_id) REFERENCES exercise(id)
+        );
+    ''')
+
+    session_columns = {
+        row[1] for row in c.execute('PRAGMA table_info(exercise_session);').fetchall()
+    }
+    required_session_columns = {
+        'id',
+        'exercise_id',
+        'repetitions',
+        'weight',
+        'timestamp',
+        'notes',
+        'perceived_exertion',
+    }
+    missing_session_columns = required_session_columns - session_columns
+    if missing_session_columns:
+        alterable = {'notes', 'perceived_exertion'}
+        for column in sorted(missing_session_columns & alterable):
+            column_type = 'TEXT' if column == 'notes' else 'INTEGER'
+            c.execute(f'ALTER TABLE exercise_session ADD COLUMN {column} {column_type};')
+        remaining_missing = missing_session_columns - alterable
+        if remaining_missing:
+            raise RuntimeError(
+                'Existing exercise_session table missing non-optional columns: '
+                + ', '.join(sorted(remaining_missing))
+            )
 
     for row in c.execute('SELECT id, name, description, training_plan_id FROM exercise_old;').fetchall():
         ex_id, name, desc, plan_id = row


### PR DESCRIPTION
## Summary
- add foreign key constraints when creating plan_exercises during migration
- validate existing plan_exercises schema before using it
- ensure exercise_session includes all required columns, adding optional ones if missing and failing fast otherwise

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1047757388322b43cf12319eeb048