### PR TITLE
Refactor templates to use a shared base layout

### DIFF
--- a/templates/add_exercise_to_plan.html
+++ b/templates/add_exercise_to_plan.html
@@ -1,57 +1,53 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Übung hinzufügen</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Übung zu "{{ training_plan.title }}" hinzufügen</h2>
-      <form method="POST">
-        {{ form.hidden_tag() }}
-        <div class="form-group">
-          <label for="existing_exercise">Vorhandene Übung verwenden</label>
-          <select name="existing_exercise_id" class="form-control">
-            <option value="">-- Neue Übung erstellen --</option>
-            {% for ex in existing_exercises %}
-              <option value="{{ ex.id }}" data-name="{{ ex.name }}" data-description="{{ ex.description or '' }}">{{ ex.name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="form-group">
-          {{ form.name.label }} {{ form.name(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.description.label }} {{ form.description(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.submit(class="btn btn-primary btn-block") }}
-        </div>
-      </form>
-      <a href="{{ url_for('training_plan_detail', training_plan_id=training_plan.id) }}" class="btn btn-secondary btn-block">Zurück</a>
+{% extends "base.html" %}
+
+{% block title %}Übung hinzufügen{% endblock %}
+
+{% block content %}
+  <h2>Übung zu "{{ training_plan.title }}" hinzufügen</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      <label for="existing_exercise">Vorhandene Übung verwenden</label>
+      <select name="existing_exercise_id" class="form-control">
+        <option value="">-- Neue Übung erstellen --</option>
+        {% for ex in existing_exercises %}
+          <option value="{{ ex.id }}" data-name="{{ ex.name }}" data-description="{{ ex.description or '' }}">{{ ex.name }}</option>
+        {% endfor %}
+      </select>
     </div>
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        const select = document.querySelector('select[name="existing_exercise_id"]');
-        const nameInput = document.getElementById('name');
-        const descInput = document.getElementById('description');
+    <div class="form-group">
+      {{ form.name.label }} {{ form.name(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.description.label }} {{ form.description(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn btn-primary btn-block") }}
+    </div>
+  </form>
+  <a href="{{ url_for('training_plan_detail', training_plan_id=training_plan.id) }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}
 
-        function fillFields() {
-          const option = select.options[select.selectedIndex];
-          if (option && option.value) {
-            nameInput.value = option.dataset.name || '';
-            descInput.value = option.dataset.description || '';
-          } else {
-            nameInput.value = '';
-            descInput.value = '';
-          }
+{% block extra_scripts %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const select = document.querySelector('select[name="existing_exercise_id"]');
+      const nameInput = document.getElementById('name');
+      const descInput = document.getElementById('description');
+
+      function fillFields() {
+        const option = select.options[select.selectedIndex];
+        if (option && option.value) {
+          nameInput.value = option.dataset.name || '';
+          descInput.value = option.dataset.description || '';
+        } else {
+          nameInput.value = '';
+          descInput.value = '';
         }
+      }
 
-        select.addEventListener('change', fillFields);
-        fillFields();
-      });
-    </script>
-  </body>
-</html>
+      select.addEventListener('change', fillFields);
+      fillFields();
+    });
+  </script>
+{% endblock %}

--- a/templates/add_exercise_to_template.html
+++ b/templates/add_exercise_to_template.html
@@ -1,27 +1,20 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Übung zur Vorlage hinzufügen</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Übung zu Vorlage: "{{ template_plan.title }}" hinzufügen</h2>
-      <form method="POST">
-        {{ form.hidden_tag() }}
-        <div class="form-group">
-          {{ form.name.label }} {{ form.name(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.description.label }} {{ form.description(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.submit(class="btn btn-primary btn-block") }}
-        </div>
-      </form>
-      <a href="{{ url_for('admin_template_plans') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% extends "base.html" %}
+
+{% block title %}Übung zur Vorlage hinzufügen{% endblock %}
+
+{% block content %}
+  <h2>Übung zu Vorlage: "{{ template_plan.title }}" hinzufügen</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.name.label }} {{ form.name(class="form-control") }}
     </div>
-  </body>
-</html>
+    <div class="form-group">
+      {{ form.description.label }} {{ form.description(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn btn-primary btn-block") }}
+    </div>
+  </form>
+  <a href="{{ url_for('admin_template_plans') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/add_session.html
+++ b/templates/add_session.html
@@ -1,193 +1,193 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Session hinzufügen für {{ exercise.name }}</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Session hinzufügen für "{{ exercise.name }}"</h2>
-      <form method="POST">
-        {{ form.hidden_tag() }}
-        <div class="form-group">
-          {{ form.repetitions.label }} {{ form.repetitions(class="form-control", pattern="\d*") }}
-        </div>
-        <div class="form-group">
-          {{ form.weight.label }} {{ form.weight(class="form-control", pattern="\d*") }}
-        </div>
-        <div class="form-group">
-          {{ form.perceived_exertion.label }} {{ form.perceived_exertion(class="form-control", pattern="\d*") }}
-        </div>
-        <div class="form-group">
-          {{ form.notes.label }} {{ form.notes(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.submit(class="btn btn-primary btn-block") }}
-        </div>
-      </form>
-      <a href="{{ url_for('exercise_detail', exercise_id=exercise.id) }}" class="btn btn-secondary btn-block">Zurück</a>
+{% extends "base.html" %}
 
-      <div class="mt-4">
-        <label for="restTime">Pause (Sekunden)</label>
-        <div class="input-group">
-          <input type="number" id="restTime" class="form-control" value="60" min="1">
-          <div class="input-group-append">
-            <button id="startRest" type="button" class="btn btn-info">Pause starten</button>
-          </div>
-        </div>
-      <div id="countdown" class="mt-2 font-weight-bold text-center"></div>
+{% block title %}Session hinzufügen für {{ exercise.name }}{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .rest-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.85);
+      color: #fff;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      z-index: 1050;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <h2>Session hinzufügen für "{{ exercise.name }}"</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.repetitions.label }} {{ form.repetitions(class="form-control", pattern="\d*") }}
+    </div>
+    <div class="form-group">
+      {{ form.weight.label }} {{ form.weight(class="form-control", pattern="\d*") }}
+    </div>
+    <div class="form-group">
+      {{ form.perceived_exertion.label }} {{ form.perceived_exertion(class="form-control", pattern="\d*") }}
+    </div>
+    <div class="form-group">
+      {{ form.notes.label }} {{ form.notes(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn btn-primary btn-block") }}
+    </div>
+  </form>
+  <a href="{{ url_for('exercise_detail', exercise_id=exercise.id) }}" class="btn btn-secondary btn-block">Zurück</a>
+
+  <div class="mt-4">
+    <label for="restTime">Pause (Sekunden)</label>
+    <div class="input-group">
+      <input type="number" id="restTime" class="form-control" value="60" min="1">
+      <div class="input-group-append">
+        <button id="startRest" type="button" class="btn btn-info">Pause starten</button>
       </div>
-    <!-- Vollbild Pausen-Overlay -->
-    <div id="restOverlay" class="rest-overlay d-none">
-      <svg width="200" height="200" class="mb-3">
-        <circle cx="100" cy="100" r="90" stroke="#555" stroke-width="10" fill="none"/>
-        <circle id="progressCircle" cx="100" cy="100" r="90" stroke="#0d6efd" stroke-width="10" fill="none" stroke-dasharray="565" stroke-dashoffset="0" style="transform: rotate(-90deg); transform-origin: center;"/>
-        <text id="timerText" x="100" y="110" text-anchor="middle" font-size="2em" fill="white">00:00</text>
-      </svg>
-      <div class="text-center">Pause ...</div>
     </div>
-    </div>
-      <script src="/static/js/main.js"></script>
-      <script>
-        const restInput = document.getElementById('restTime');
-        const savedRest = localStorage.getItem('lastRestTime');
-        if (savedRest) {
-          restInput.value = savedRest;
-        }
+    <div id="countdown" class="mt-2 font-weight-bold text-center"></div>
+  </div>
 
-        document.querySelector('form').addEventListener('submit', function(e) {
-        if (!navigator.onLine) {
-          e.preventDefault();
-          const rpeValue = document.getElementById('perceived_exertion').value;
-          const parsedRpe = rpeValue ? parseInt(rpeValue, 10) : null;
-          const normalizedRpe = Number.isNaN(parsedRpe) ? null : parsedRpe;
-          saveOfflineSession({
-            exercise_id: {{ exercise.id }},
-            repetitions: document.getElementById('repetitions').value,
-            weight: document.getElementById('weight').value,
-            perceived_exertion: normalizedRpe,
-            notes: document.getElementById('notes').value || null,
-            timestamp: new Date().toISOString()
-          });
-          alert('Offline: Session wird gespeichert und beim n\u00e4chsten Online-Sein synchronisiert.');
-          window.location.href = "{{ url_for('exercise_detail', exercise_id=exercise.id) }}";
-        }
-      });
+  <div id="restOverlay" class="rest-overlay d-none">
+    <svg width="200" height="200" class="mb-3">
+      <circle cx="100" cy="100" r="90" stroke="#555" stroke-width="10" fill="none"></circle>
+      <circle id="progressCircle" cx="100" cy="100" r="90" stroke="#0d6efd" stroke-width="10" fill="none" stroke-dasharray="565" stroke-dashoffset="0" style="transform: rotate(-90deg); transform-origin: center;"></circle>
+      <text id="timerText" x="100" y="110" text-anchor="middle" font-size="2em" fill="white">00:00</text>
+    </svg>
+    <div class="text-center">Pause ...</div>
+  </div>
+{% endblock %}
 
-        function formatTime(sec) {
-        const m = Math.floor(sec / 60).toString().padStart(2, '0');
-        const s = (sec % 60).toString().padStart(2, '0');
-        return m + ':' + s;
+{% block extra_scripts %}
+  <script>
+    const restInput = document.getElementById('restTime');
+    const savedRest = localStorage.getItem('lastRestTime');
+    if (savedRest) {
+      restInput.value = savedRest;
+    }
+
+    document.querySelector('form').addEventListener('submit', function (e) {
+      if (!navigator.onLine) {
+        e.preventDefault();
+        const rpeValue = document.getElementById('perceived_exertion').value;
+        const parsedRpe = rpeValue ? parseInt(rpeValue, 10) : null;
+        const normalizedRpe = Number.isNaN(parsedRpe) ? null : parsedRpe;
+        saveOfflineSession({
+          exercise_id: {{ exercise.id }},
+          repetitions: document.getElementById('repetitions').value,
+          weight: document.getElementById('weight').value,
+          perceived_exertion: normalizedRpe,
+          notes: document.getElementById('notes').value || null,
+          timestamp: new Date().toISOString()
+        });
+        alert('Offline: Session wird gespeichert und beim nächsten Online-Sein synchronisiert.');
+        window.location.href = "{{ url_for('exercise_detail', exercise_id=exercise.id) }}";
+      }
+    });
+
+    function formatTime(sec) {
+      const m = Math.floor(sec / 60).toString().padStart(2, '0');
+      const s = (sec % 60).toString().padStart(2, '0');
+      return m + ':' + s;
+    }
+
+    const overlay = document.getElementById('restOverlay');
+    const progressCircle = document.getElementById('progressCircle');
+    const timerText = document.getElementById('timerText');
+    let wakeLock = null;
+
+    async function requestWakeLock() {
+      if ('wakeLock' in navigator) {
+        try {
+          wakeLock = await navigator.wakeLock.request('screen');
+        } catch (err) {
+          console.error('Wake Lock error:', err);
+        }
+      }
+    }
+
+    function releaseWakeLock() {
+      if (wakeLock) {
+        wakeLock.release();
+        wakeLock = null;
+      }
+    }
+
+    document.getElementById('startRest').addEventListener('click', function () {
+      const input = document.getElementById('restTime');
+      let remaining = parseInt(input.value, 10) || 0;
+      if (remaining <= 0) {
+        return;
+      }
+      const reps = document.getElementById('repetitions').value;
+      const weight = document.getElementById('weight').value;
+      const notes = document.getElementById('notes').value;
+      const rpeRaw = document.getElementById('perceived_exertion').value;
+      const parsedRpe = rpeRaw ? parseInt(rpeRaw, 10) : null;
+      const normalizedRpe = Number.isNaN(parsedRpe) ? null : parsedRpe;
+      if (!reps || !weight) {
+        alert('Bitte Wiederholungen und Gewicht eingeben.');
+        return;
+      }
+      localStorage.setItem('lastRestTime', remaining);
+
+      const sessionData = {
+        repetitions: reps,
+        weight: weight,
+        notes: notes || null,
+        perceived_exertion: normalizedRpe
+      };
+
+      function startCountdown() {
+        document.getElementById('startRest').disabled = true;
+        input.disabled = true;
+        overlay.classList.remove('d-none');
+        const total = remaining;
+        const circumference = 565;
+        progressCircle.style.strokeDasharray = circumference;
+        function updateDisplay(sec) {
+          timerText.textContent = formatTime(sec);
+          progressCircle.style.strokeDashoffset = circumference * (1 - sec / total);
+        }
+        const endTime = Date.now() + remaining * 1000;
+        updateDisplay(remaining);
+        requestWakeLock();
+        const interval = setInterval(() => {
+          remaining = Math.ceil((endTime - Date.now()) / 1000);
+          updateDisplay(Math.max(remaining, 0));
+          if (remaining <= 0) {
+            clearInterval(interval);
+            releaseWakeLock();
+            window.location.href = "{{ url_for('exercise_detail', exercise_id=exercise.id) }}";
+          }
+        }, 1000);
       }
 
-        const overlay = document.getElementById('restOverlay');
-        const progressCircle = document.getElementById('progressCircle');
-        const timerText = document.getElementById('timerText');
-        let wakeLock = null;
-
-        async function requestWakeLock() {
-          if ('wakeLock' in navigator) {
-            try {
-              wakeLock = await navigator.wakeLock.request('screen');
-            } catch (err) {
-              console.error('Wake Lock error:', err);
-            }
-          }
-        }
-
-        function releaseWakeLock() {
-          if (wakeLock) {
-            wakeLock.release();
-            wakeLock = null;
-          }
-        }
-
-        document.getElementById('startRest').addEventListener('click', function() {
-        const input = document.getElementById('restTime');
-        let remaining = parseInt(input.value, 10) || 0;
-        if (remaining <= 0) { return; }
-        const reps = document.getElementById('repetitions').value;
-        const weight = document.getElementById('weight').value;
-        const notes = document.getElementById('notes').value;
-        const rpeRaw = document.getElementById('perceived_exertion').value;
-        const parsedRpe = rpeRaw ? parseInt(rpeRaw, 10) : null;
-        const normalizedRpe = Number.isNaN(parsedRpe) ? null : parsedRpe;
-        if (!reps || !weight) {
-          alert('Bitte Wiederholungen und Gewicht eingeben.');
-          return;
-        }
-        localStorage.setItem('lastRestTime', remaining);
-
-        const sessionData = {
+      if (navigator.onLine) {
+        fetch('/api/exercises/{{ exercise.id }}/sessions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(sessionData)
+        }).then(startCountdown).catch(function () {
+          alert('Fehler beim Speichern der Session.');
+        });
+      } else {
+        saveOfflineSession({
+          exercise_id: {{ exercise.id }},
           repetitions: reps,
           weight: weight,
           notes: notes || null,
-          perceived_exertion: normalizedRpe
-        };
-
-        function startCountdown() {
-          document.getElementById('startRest').disabled = true;
-          input.disabled = true;
-          overlay.classList.remove('d-none');
-          const total = remaining;
-          const circumference = 565;
-          progressCircle.style.strokeDasharray = circumference;
-          function updateDisplay(sec) {
-            timerText.textContent = formatTime(sec);
-            progressCircle.style.strokeDashoffset = circumference * (1 - sec / total);
-          }
-          const endTime = Date.now() + remaining * 1000;
-          updateDisplay(remaining);
-          requestWakeLock();
-          const interval = setInterval(() => {
-            remaining = Math.ceil((endTime - Date.now()) / 1000);
-            updateDisplay(Math.max(remaining, 0));
-            if (remaining <= 0) {
-              clearInterval(interval);
-              releaseWakeLock();
-              window.location.href = "{{ url_for('exercise_detail', exercise_id=exercise.id) }}";
-            }
-          }, 1000);
-        }
-
-        if (navigator.onLine) {
-          fetch('/api/exercises/{{ exercise.id }}/sessions', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(sessionData)
-          }).then(startCountdown).catch(function() {
-            alert('Fehler beim Speichern der Session.');
-          });
-        } else {
-          saveOfflineSession({
-            exercise_id: {{ exercise.id }},
-            repetitions: reps,
-            weight: weight,
-            notes: notes || null,
-            perceived_exertion: normalizedRpe,
-            timestamp: new Date().toISOString()
-          });
-          startCountdown();
-        }
+          perceived_exertion: normalizedRpe,
+          timestamp: new Date().toISOString()
         });
-    </script>
-    <style>
-      .rest-overlay {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(0,0,0,0.85);
-        color: #fff;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        z-index: 1050;
+        startCountdown();
       }
-    </style>
-  </body>
-</html>
+    });
+  </script>
+{% endblock %}

--- a/templates/admin_change_password.html
+++ b/templates/admin_change_password.html
@@ -1,27 +1,20 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Admin – Passwort ändern für {{ user.username }}</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Passwort ändern für {{ user.username }}</h2>
-      <form method="POST">
-        {{ form.hidden_tag() }}
-        <div class="form-group">
-          {{ form.new_password.label }} {{ form.new_password(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.confirm.label }} {{ form.confirm(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.submit(class="btn btn-primary btn-block") }}
-        </div>
-      </form>
-      <a href="{{ url_for('admin_overview') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% extends "base.html" %}
+
+{% block title %}Admin – Passwort ändern für {{ user.username }}{% endblock %}
+
+{% block content %}
+  <h2>Passwort ändern für {{ user.username }}</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.new_password.label }} {{ form.new_password(class="form-control") }}
     </div>
-  </body>
-</html>
+    <div class="form-group">
+      {{ form.confirm.label }} {{ form.confirm(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn btn-primary btn-block") }}
+    </div>
+  </form>
+  <a href="{{ url_for('admin_overview') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/admin_footer_links.html
+++ b/templates/admin_footer_links.html
@@ -1,54 +1,46 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Admin – Footer Links</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Footer Links verwalten</h2>
-      <form method="POST" class="mb-3">
-        {{ form.hidden_tag() }}
-        <div class="form-row">
-          <div class="col">
-            {{ form.title.label }} {{ form.title(class="form-control") }}
-          </div>
-          <div class="col">
-            {{ form.url.label }} {{ form.url(class="form-control") }}
-          </div>
-          <div class="col-auto">
-            {{ form.submit(class="btn btn-primary mt-4") }}
-          </div>
-        </div>
-      </form>
-      <table class="table table-striped">
-        <thead>
-          <tr>
-            <th>Text</th>
-            <th>URL</th>
-            <th>Aktionen</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for link in links %}
-          <tr>
-            <td>{{ link.title }}</td>
-            <td>{{ link.url }}</td>
-            <td>
-              <a href="{{ url_for('edit_footer_link', link_id=link.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
-              <form action="{{ url_for('delete_footer_link', link_id=link.id) }}" method="POST" style="display:inline;">
-                {{ delete_form.hidden_tag() }}
-                {{ delete_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
-              </form>
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-      <a href="{{ url_for('admin_overview') }}" class="btn btn-secondary btn-block">Zurück</a>
-    </div>
-  </body>
-</html>
+{% extends "base.html" %}
 
+{% block title %}Admin – Footer Links{% endblock %}
+
+{% block content %}
+  <h2>Footer Links verwalten</h2>
+  <form method="POST" class="mb-3">
+    {{ form.hidden_tag() }}
+    <div class="form-row">
+      <div class="col">
+        {{ form.title.label }} {{ form.title(class="form-control") }}
+      </div>
+      <div class="col">
+        {{ form.url.label }} {{ form.url(class="form-control") }}
+      </div>
+      <div class="col-auto">
+        {{ form.submit(class="btn btn-primary mt-4") }}
+      </div>
+    </div>
+  </form>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Text</th>
+        <th>URL</th>
+        <th>Aktionen</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for link in links %}
+        <tr>
+          <td>{{ link.title }}</td>
+          <td>{{ link.url }}</td>
+          <td>
+            <a href="{{ url_for('edit_footer_link', link_id=link.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
+            <form action="{{ url_for('delete_footer_link', link_id=link.id) }}" method="POST" class="d-inline">
+              {{ delete_form.hidden_tag() }}
+              {{ delete_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
+            </form>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <a href="{{ url_for('admin_overview') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/admin_footer_links.html
+++ b/templates/admin_footer_links.html
@@ -18,29 +18,31 @@
       </div>
     </div>
   </form>
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th>Text</th>
-        <th>URL</th>
-        <th>Aktionen</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for link in links %}
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
         <tr>
-          <td>{{ link.title }}</td>
-          <td>{{ link.url }}</td>
-          <td>
-            <a href="{{ url_for('edit_footer_link', link_id=link.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
-            <form action="{{ url_for('delete_footer_link', link_id=link.id) }}" method="POST" class="d-inline">
-              {{ delete_form.hidden_tag() }}
-              {{ delete_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
-            </form>
-          </td>
+          <th>Text</th>
+          <th>URL</th>
+          <th>Aktionen</th>
         </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        {% for link in links %}
+          <tr>
+            <td>{{ link.title }}</td>
+            <td>{{ link.url }}</td>
+            <td>
+              <a href="{{ url_for('edit_footer_link', link_id=link.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
+              <form action="{{ url_for('delete_footer_link', link_id=link.id) }}" method="POST" class="d-inline">
+                {{ delete_form.hidden_tag() }}
+                {{ delete_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
+              </form>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
   <a href="{{ url_for('admin_overview') }}" class="btn btn-secondary btn-block">Zurück</a>
 {% endblock %}

--- a/templates/admin_footer_pages.html
+++ b/templates/admin_footer_pages.html
@@ -1,54 +1,46 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Admin – Footer-Seiten</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Footer-Seiten verwalten</h2>
-      <form method="POST" class="mb-3">
-        {{ form.hidden_tag() }}
-        <div class="form-row">
-          <div class="col">
-            {{ form.title.label }} {{ form.title(class="form-control") }}
-          </div>
-          <div class="col">
-            {{ form.content.label }} {{ form.content(class="form-control", rows=4) }}
-          </div>
-          <div class="col-auto">
-            {{ form.submit(class="btn btn-primary mt-4") }}
-          </div>
-        </div>
-      </form>
-      <table class="table table-striped">
-        <thead>
-          <tr>
-            <th>Text</th>
-            <th>Vorschau</th>
-            <th>Aktionen</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for page in pages %}
-          <tr>
-            <td>{{ page.title }}</td>
-            <td>{{ page.content[:30] }}{% if page.content|length > 30 %}...{% endif %}</td>
-            <td>
-              <a href="{{ url_for('edit_footer_page', page_id=page.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
-              <form action="{{ url_for('delete_footer_page', page_id=page.id) }}" method="POST" style="display:inline;">
-                {{ delete_form.hidden_tag() }}
-                {{ delete_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
-              </form>
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-      <a href="{{ url_for('admin_overview') }}" class="btn btn-secondary btn-block">Zurück</a>
-    </div>
-  </body>
-</html>
+{% extends "base.html" %}
 
+{% block title %}Admin – Footer-Seiten{% endblock %}
+
+{% block content %}
+  <h2>Footer-Seiten verwalten</h2>
+  <form method="POST" class="mb-3">
+    {{ form.hidden_tag() }}
+    <div class="form-row">
+      <div class="col">
+        {{ form.title.label }} {{ form.title(class="form-control") }}
+      </div>
+      <div class="col">
+        {{ form.content.label }} {{ form.content(class="form-control", rows=4) }}
+      </div>
+      <div class="col-auto">
+        {{ form.submit(class="btn btn-primary mt-4") }}
+      </div>
+    </div>
+  </form>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Text</th>
+        <th>Vorschau</th>
+        <th>Aktionen</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for page in pages %}
+        <tr>
+          <td>{{ page.title }}</td>
+          <td>{{ page.content[:30] }}{% if page.content|length > 30 %}...{% endif %}</td>
+          <td>
+            <a href="{{ url_for('edit_footer_page', page_id=page.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
+            <form action="{{ url_for('delete_footer_page', page_id=page.id) }}" method="POST" class="d-inline">
+              {{ delete_form.hidden_tag() }}
+              {{ delete_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
+            </form>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <a href="{{ url_for('admin_overview') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/admin_footer_pages.html
+++ b/templates/admin_footer_pages.html
@@ -18,29 +18,31 @@
       </div>
     </div>
   </form>
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th>Text</th>
-        <th>Vorschau</th>
-        <th>Aktionen</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for page in pages %}
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
         <tr>
-          <td>{{ page.title }}</td>
-          <td>{{ page.content[:30] }}{% if page.content|length > 30 %}...{% endif %}</td>
-          <td>
-            <a href="{{ url_for('edit_footer_page', page_id=page.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
-            <form action="{{ url_for('delete_footer_page', page_id=page.id) }}" method="POST" class="d-inline">
-              {{ delete_form.hidden_tag() }}
-              {{ delete_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
-            </form>
-          </td>
+          <th>Text</th>
+          <th>Vorschau</th>
+          <th>Aktionen</th>
         </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        {% for page in pages %}
+          <tr>
+            <td>{{ page.title }}</td>
+            <td>{{ page.content[:30] }}{% if page.content|length > 30 %}...{% endif %}</td>
+            <td>
+              <a href="{{ url_for('edit_footer_page', page_id=page.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
+              <form action="{{ url_for('delete_footer_page', page_id=page.id) }}" method="POST" class="d-inline">
+                {{ delete_form.hidden_tag() }}
+                {{ delete_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
+              </form>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
   <a href="{{ url_for('admin_overview') }}" class="btn btn-secondary btn-block">Zurück</a>
 {% endblock %}

--- a/templates/admin_overview.html
+++ b/templates/admin_overview.html
@@ -1,64 +1,57 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Admin – Benutzerübersicht</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Admin – Benutzerübersicht</h2>
-      <a href="{{ url_for('admin_footer_pages') }}" class="btn btn-info mb-3 btn-block">Footer-Seiten verwalten</a>
+{% extends "base.html" %}
 
-      <table class="table table-striped">
-        <thead>
-          <tr>
-            <th>Benutzername</th>
-            <th>Registriert am</th>
-            <th>Letzter Login</th>
-            <th>Trainer</th>
-            <th>Aktionen</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for user in users %}
-            <tr>
-              <td>{{ user.username }}</td>
-              <td>{{ user.registration_date.strftime('%d.%m.%Y %H:%M') }}</td>
-              <td>
-                {% if user.last_login %}
-                  {{ user.last_login.strftime('%d.%m.%Y %H:%M') }}
-                {% else %}
-                  -
-                {% endif %}
-              </td>
-              <td>{{ 'Ja' if user.is_trainer else 'Nein' }}</td>
-              <td>
-                {% if not user.is_trainer %}
-                <form action="{{ url_for('admin_set_trainer', user_id=user.id) }}" method="POST" style="display:inline;">
-                  {{ set_trainer_form.hidden_tag() }}
-                  {{ set_trainer_form.submit(class="btn btn-secondary btn-sm", value='Trainer setzen') }}
-                </form>
-                {% else %}
-                <form action="{{ url_for('admin_remove_trainer', user_id=user.id) }}" method="POST" style="display:inline;">
-                  {{ remove_trainer_form.hidden_tag() }}
-                  {{ remove_trainer_form.submit(class="btn btn-secondary btn-sm", value='Trainer entfernen') }}
-                </form>
-                {% endif %}
-                <a href="{{ url_for('admin_change_password', user_id=user.id) }}" class="btn btn-primary btn-sm">Passwort ändern</a>
-                {% if user.id != current_user.id %}
-                  <form action="{{ url_for('admin_delete_user', user_id=user.id) }}" method="POST" style="display:inline;" onsubmit="return confirm('Benutzer wirklich löschen?');">
-                    {{ delete_user_form.hidden_tag() }}
-                    {{ delete_user_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
-                  </form>
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-      <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block">Zurück</a>
-    </div>
-  </body>
-</html>
+{% block title %}Admin – Benutzerübersicht{% endblock %}
+
+{% block content %}
+  <h2>Admin – Benutzerübersicht</h2>
+  <a href="{{ url_for('admin_footer_pages') }}" class="btn btn-info mb-3 btn-block">Footer-Seiten verwalten</a>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Benutzername</th>
+        <th>Registriert am</th>
+        <th>Letzter Login</th>
+        <th>Trainer</th>
+        <th>Aktionen</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for user in users %}
+        <tr>
+          <td>{{ user.username }}</td>
+          <td>{{ user.registration_date.strftime('%d.%m.%Y %H:%M') }}</td>
+          <td>
+            {% if user.last_login %}
+              {{ user.last_login.strftime('%d.%m.%Y %H:%M') }}
+            {% else %}
+              -
+            {% endif %}
+          </td>
+          <td>{{ 'Ja' if user.is_trainer else 'Nein' }}</td>
+          <td>
+            {% if not user.is_trainer %}
+              <form action="{{ url_for('admin_set_trainer', user_id=user.id) }}" method="POST" class="d-inline">
+                {{ set_trainer_form.hidden_tag() }}
+                {{ set_trainer_form.submit(class="btn btn-secondary btn-sm", value='Trainer setzen') }}
+              </form>
+            {% else %}
+              <form action="{{ url_for('admin_remove_trainer', user_id=user.id) }}" method="POST" class="d-inline">
+                {{ remove_trainer_form.hidden_tag() }}
+                {{ remove_trainer_form.submit(class="btn btn-secondary btn-sm", value='Trainer entfernen') }}
+              </form>
+            {% endif %}
+            <a href="{{ url_for('admin_change_password', user_id=user.id) }}" class="btn btn-primary btn-sm">Passwort ändern</a>
+            {% if user.id != current_user.id %}
+              <form action="{{ url_for('admin_delete_user', user_id=user.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Benutzer wirklich löschen?');">
+                {{ delete_user_form.hidden_tag() }}
+                {{ delete_user_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
+              </form>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/admin_overview.html
+++ b/templates/admin_overview.html
@@ -6,52 +6,54 @@
   <h2>Admin – Benutzerübersicht</h2>
   <a href="{{ url_for('admin_footer_pages') }}" class="btn btn-info mb-3 btn-block">Footer-Seiten verwalten</a>
 
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th>Benutzername</th>
-        <th>Registriert am</th>
-        <th>Letzter Login</th>
-        <th>Trainer</th>
-        <th>Aktionen</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for user in users %}
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
         <tr>
-          <td>{{ user.username }}</td>
-          <td>{{ user.registration_date.strftime('%d.%m.%Y %H:%M') }}</td>
-          <td>
-            {% if user.last_login %}
-              {{ user.last_login.strftime('%d.%m.%Y %H:%M') }}
-            {% else %}
-              -
-            {% endif %}
-          </td>
-          <td>{{ 'Ja' if user.is_trainer else 'Nein' }}</td>
-          <td>
-            {% if not user.is_trainer %}
-              <form action="{{ url_for('admin_set_trainer', user_id=user.id) }}" method="POST" class="d-inline">
-                {{ set_trainer_form.hidden_tag() }}
-                {{ set_trainer_form.submit(class="btn btn-secondary btn-sm", value='Trainer setzen') }}
-              </form>
-            {% else %}
-              <form action="{{ url_for('admin_remove_trainer', user_id=user.id) }}" method="POST" class="d-inline">
-                {{ remove_trainer_form.hidden_tag() }}
-                {{ remove_trainer_form.submit(class="btn btn-secondary btn-sm", value='Trainer entfernen') }}
-              </form>
-            {% endif %}
-            <a href="{{ url_for('admin_change_password', user_id=user.id) }}" class="btn btn-primary btn-sm">Passwort ändern</a>
-            {% if user.id != current_user.id %}
-              <form action="{{ url_for('admin_delete_user', user_id=user.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Benutzer wirklich löschen?');">
-                {{ delete_user_form.hidden_tag() }}
-                {{ delete_user_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
-              </form>
-            {% endif %}
-          </td>
+          <th>Benutzername</th>
+          <th>Registriert am</th>
+          <th>Letzter Login</th>
+          <th>Trainer</th>
+          <th>Aktionen</th>
         </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        {% for user in users %}
+          <tr>
+            <td>{{ user.username }}</td>
+            <td>{{ user.registration_date.strftime('%d.%m.%Y %H:%M') }}</td>
+            <td>
+              {% if user.last_login %}
+                {{ user.last_login.strftime('%d.%m.%Y %H:%M') }}
+              {% else %}
+                -
+              {% endif %}
+            </td>
+            <td>{{ 'Ja' if user.is_trainer else 'Nein' }}</td>
+            <td>
+              {% if not user.is_trainer %}
+                <form action="{{ url_for('admin_set_trainer', user_id=user.id) }}" method="POST" class="d-inline">
+                  {{ set_trainer_form.hidden_tag() }}
+                  {{ set_trainer_form.submit(class="btn btn-secondary btn-sm", value='Trainer setzen') }}
+                </form>
+              {% else %}
+                <form action="{{ url_for('admin_remove_trainer', user_id=user.id) }}" method="POST" class="d-inline">
+                  {{ remove_trainer_form.hidden_tag() }}
+                  {{ remove_trainer_form.submit(class="btn btn-secondary btn-sm", value='Trainer entfernen') }}
+                </form>
+              {% endif %}
+              <a href="{{ url_for('admin_change_password', user_id=user.id) }}" class="btn btn-primary btn-sm">Passwort ändern</a>
+              {% if user.id != current_user.id %}
+                <form action="{{ url_for('admin_delete_user', user_id=user.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Benutzer wirklich löschen?');">
+                  {{ delete_user_form.hidden_tag() }}
+                  {{ delete_user_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
+                </form>
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
   <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block">Zurück</a>
 {% endblock %}

--- a/templates/admin_template_plans.html
+++ b/templates/admin_template_plans.html
@@ -1,53 +1,46 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Admin – Template Trainingspläne</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Admin – Template Trainingspläne</h2>
-      <a href="{{ url_for('create_template_plan') }}" class="btn btn-success mb-3 btn-block">
-        Neuen Template Trainingsplan erstellen
-      </a>
-      <table class="table table-striped">
-        <thead>
-          <tr>
-            <th>Titel</th>
-            <th>Beschreibung</th>
-            <th>Sichtbar</th>
-            <th>Aktionen</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for tpl in templates %}
-          <tr>
-            <td>{{ tpl.title }}</td>
-            <td>{{ tpl.description }}</td>
-            <td>{{ 'Ja' if tpl.is_visible else 'Nein' }}</td>
-            <td>
-              <a href="{{ url_for('add_exercise_to_template', template_plan_id=tpl.id) }}" class="btn btn-primary btn-sm">Übung hinzufügen</a>
-              <a href="{{ url_for('edit_template_plan', template_plan_id=tpl.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
-              <form action="{{ url_for('toggle_template_visibility', template_plan_id=tpl.id) }}" method="POST" style="display:inline;">
-                {{ toggle_form.hidden_tag() }}
-                {% if tpl.is_visible %}
+{% extends "base.html" %}
+
+{% block title %}Admin – Template Trainingspläne{% endblock %}
+
+{% block content %}
+  <h2>Admin – Template Trainingspläne</h2>
+  <a href="{{ url_for('create_template_plan') }}" class="btn btn-success mb-3 btn-block">
+    Neuen Template Trainingsplan erstellen
+  </a>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Titel</th>
+        <th>Beschreibung</th>
+        <th>Sichtbar</th>
+        <th>Aktionen</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for tpl in templates %}
+        <tr>
+          <td>{{ tpl.title }}</td>
+          <td>{{ tpl.description }}</td>
+          <td>{{ 'Ja' if tpl.is_visible else 'Nein' }}</td>
+          <td>
+            <a href="{{ url_for('add_exercise_to_template', template_plan_id=tpl.id) }}" class="btn btn-primary btn-sm">Übung hinzufügen</a>
+            <a href="{{ url_for('edit_template_plan', template_plan_id=tpl.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
+            <form action="{{ url_for('toggle_template_visibility', template_plan_id=tpl.id) }}" method="POST" class="d-inline">
+              {{ toggle_form.hidden_tag() }}
+              {% if tpl.is_visible %}
                 {{ toggle_form.submit(class="btn btn-warning btn-sm", value='Unsichtbar') }}
-                {% else %}
+              {% else %}
                 {{ toggle_form.submit(class="btn btn-warning btn-sm", value='Sichtbar') }}
-                {% endif %}
-              </form>
-              <form action="{{ url_for('delete_template_plan', template_plan_id=tpl.id) }}" method="POST" style="display:inline;" onsubmit="return confirm('Template Trainingsplan wirklich löschen?');">
-                {{ delete_tpl_form.hidden_tag() }}
-                {{ delete_tpl_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
-              </form>
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-      <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block">Zurück</a>
-    </div>
-  </body>
-</html>
+              {% endif %}
+            </form>
+            <form action="{{ url_for('delete_template_plan', template_plan_id=tpl.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Template Trainingsplan wirklich löschen?');">
+              {{ delete_tpl_form.hidden_tag() }}
+              {{ delete_tpl_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
+            </form>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/admin_template_plans.html
+++ b/templates/admin_template_plans.html
@@ -7,40 +7,42 @@
   <a href="{{ url_for('create_template_plan') }}" class="btn btn-success mb-3 btn-block">
     Neuen Template Trainingsplan erstellen
   </a>
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th>Titel</th>
-        <th>Beschreibung</th>
-        <th>Sichtbar</th>
-        <th>Aktionen</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for tpl in templates %}
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
         <tr>
-          <td>{{ tpl.title }}</td>
-          <td>{{ tpl.description }}</td>
-          <td>{{ 'Ja' if tpl.is_visible else 'Nein' }}</td>
-          <td>
-            <a href="{{ url_for('add_exercise_to_template', template_plan_id=tpl.id) }}" class="btn btn-primary btn-sm">Übung hinzufügen</a>
-            <a href="{{ url_for('edit_template_plan', template_plan_id=tpl.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
-            <form action="{{ url_for('toggle_template_visibility', template_plan_id=tpl.id) }}" method="POST" class="d-inline">
-              {{ toggle_form.hidden_tag() }}
-              {% if tpl.is_visible %}
-                {{ toggle_form.submit(class="btn btn-warning btn-sm", value='Unsichtbar') }}
-              {% else %}
-                {{ toggle_form.submit(class="btn btn-warning btn-sm", value='Sichtbar') }}
-              {% endif %}
-            </form>
-            <form action="{{ url_for('delete_template_plan', template_plan_id=tpl.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Template Trainingsplan wirklich löschen?');">
-              {{ delete_tpl_form.hidden_tag() }}
-              {{ delete_tpl_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
-            </form>
-          </td>
+          <th>Titel</th>
+          <th>Beschreibung</th>
+          <th>Sichtbar</th>
+          <th>Aktionen</th>
         </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        {% for tpl in templates %}
+          <tr>
+            <td>{{ tpl.title }}</td>
+            <td>{{ tpl.description }}</td>
+            <td>{{ 'Ja' if tpl.is_visible else 'Nein' }}</td>
+            <td>
+              <a href="{{ url_for('add_exercise_to_template', template_plan_id=tpl.id) }}" class="btn btn-primary btn-sm">Übung hinzufügen</a>
+              <a href="{{ url_for('edit_template_plan', template_plan_id=tpl.id) }}" class="btn btn-info btn-sm">Bearbeiten</a>
+              <form action="{{ url_for('toggle_template_visibility', template_plan_id=tpl.id) }}" method="POST" class="d-inline">
+                {{ toggle_form.hidden_tag() }}
+                {% if tpl.is_visible %}
+                  {{ toggle_form.submit(class="btn btn-warning btn-sm", value='Unsichtbar') }}
+                {% else %}
+                  {{ toggle_form.submit(class="btn btn-warning btn-sm", value='Sichtbar') }}
+                {% endif %}
+              </form>
+              <form action="{{ url_for('delete_template_plan', template_plan_id=tpl.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Template Trainingsplan wirklich löschen?');">
+                {{ delete_tpl_form.hidden_tag() }}
+                {{ delete_tpl_form.submit(class="btn btn-danger btn-sm", value='Löschen') }}
+              </form>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
   <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block">Zurück</a>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>{% block title %}Fitness App{% endblock %}</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+    {% block extra_head %}{% endblock %}
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <a class="navbar-brand" href="{{ url_for('index') }}">Fitness App</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Navigation umschalten">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav mr-auto">
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('index') }}">Start</a>
+          </li>
+          {% if current_user.is_authenticated %}
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('template_plans') }}">Vorlagen</a>
+            </li>
+            {% if current_user.is_admin %}
+              <li class="nav-item">
+                <a class="nav-link" href="{{ url_for('admin_overview') }}">Admin</a>
+              </li>
+            {% endif %}
+          {% endif %}
+        </ul>
+        <ul class="navbar-nav">
+          {% if current_user.is_authenticated %}
+            <li class="nav-item">
+              <span class="navbar-text mr-2">Hallo, {{ current_user.username }}!</span>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+            </li>
+          {% else %}
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('login') }}">Login</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('register') }}">Registrieren</a>
+            </li>
+          {% endif %}
+        </ul>
+      </div>
+    </nav>
+    <main class="container mt-4">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            <div class="alert alert-{{ category }}" role="alert">
+              {{ message }}
+            </div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-LtrjvnR4/Jkk+1AnsuGukdxbCJO/q9OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', function () {
+          navigator.serviceWorker.register('{{ url_for('static', filename='sw.js') }}').then(function (registration) {
+            console.log('ServiceWorker registration successful with scope: ', registration.scope);
+          }, function (err) {
+            console.log('ServiceWorker registration failed: ', err);
+          });
+        });
+      }
+    </script>
+    {% block extra_scripts %}{% endblock %}
+  </body>
+</html>

--- a/templates/create_template_plan.html
+++ b/templates/create_template_plan.html
@@ -1,27 +1,20 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Template Trainingsplan erstellen</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Template Trainingsplan erstellen</h2>
-      <form method="POST">
-        {{ form.hidden_tag() }}
-        <div class="form-group">
-          {{ form.title.label }} {{ form.title(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.description.label }} {{ form.description(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.submit(class="btn btn-primary btn-block") }}
-        </div>
-      </form>
-      <a href="{{ url_for('admin_template_plans') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% extends "base.html" %}
+
+{% block title %}Template Trainingsplan erstellen{% endblock %}
+
+{% block content %}
+  <h2>Template Trainingsplan erstellen</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.title.label }} {{ form.title(class="form-control") }}
     </div>
-  </body>
-</html>
+    <div class="form-group">
+      {{ form.description.label }} {{ form.description(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn btn-primary btn-block") }}
+    </div>
+  </form>
+  <a href="{{ url_for('admin_template_plans') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/create_training_plan.html
+++ b/templates/create_training_plan.html
@@ -1,27 +1,20 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Trainingsplan erstellen</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Trainingsplan erstellen</h2>
-      <form method="POST">
-        {{ form.hidden_tag() }}
-        <div class="form-group">
-          {{ form.title.label }} {{ form.title(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.description.label }} {{ form.description(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.submit(class="btn btn-primary btn-block") }}
-        </div>
-      </form>
-      <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% extends "base.html" %}
+
+{% block title %}Trainingsplan erstellen{% endblock %}
+
+{% block content %}
+  <h2>Trainingsplan erstellen</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.title.label }} {{ form.title(class="form-control") }}
     </div>
-  </body>
-</html>
+    <div class="form-group">
+      {{ form.description.label }} {{ form.description(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn btn-primary btn-block") }}
+    </div>
+  </form>
+  <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,48 +1,39 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Dashboard</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Dashboard</h2>
-      <p>
-        Willkommen, {{ current_user.username }}!
-        <a href="{{ url_for('logout') }}" class="btn btn-outline-secondary btn-sm ml-2">Logout</a>
-        {% if current_user.is_admin %}
-          <a href="{{ url_for('admin_overview') }}" class="btn btn-warning btn-sm ml-2">Admin</a>
-        {% endif %}
-      </p>
-      <h3>Deine Trainingspläne</h3>
-      <a href="{{ url_for('create_training_plan') }}" class="btn btn-success mb-3 btn-block">Neuen Trainingsplan erstellen</a>
-      <ul class="list-group">
-        {% for plan in training_plans %}
-          <li class="list-group-item">
-            <a href="{{ url_for('training_plan_detail', training_plan_id=plan.id) }}">{{ plan.title }}</a>
-          </li>
-        {% endfor %}
-      </ul>
-      <a href="{{ url_for('template_plans') }}" class="btn btn-info btn-block mt-3">Vorlagen ansehen</a>
-      <div class="dropdown mt-3">
-        <button class="btn btn-outline-primary btn-block dropdown-toggle" type="button" id="dashboardActionsDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Weitere Aktionen
-        </button>
-        <div class="dropdown-menu dropdown-menu-right w-100" aria-labelledby="dashboardActionsDropdown">
-          <h6 class="dropdown-header">Datenexport</h6>
-          <a class="dropdown-item" href="{{ url_for('export_training_data') }}">Trainingsdaten als JSON exportieren</a>
-          <a class="dropdown-item" href="{{ url_for('export_training_data', format='csv') }}">Trainingsdaten als CSV exportieren</a>
-          <div class="dropdown-divider"></div>
-          <span class="dropdown-item-text text-muted small">JSON-Export unterstützt optionale ZIP-Komprimierung über <code>?zip=1</code>.</span>
-        </div>
-      </div>
-      {% if current_user.is_admin or current_user.is_trainer %}
-        <a href="{{ url_for('admin_template_plans') }}" class="btn btn-warning btn-block mt-3">Template Trainingspläne verwalten</a>
-      {% endif %}
+{% extends "base.html" %}
+
+{% block title %}Dashboard{% endblock %}
+
+{% block content %}
+  <h2>Dashboard</h2>
+  <p>
+    Willkommen, {{ current_user.username }}!
+    <a href="{{ url_for('logout') }}" class="btn btn-outline-secondary btn-sm ml-2">Logout</a>
+    {% if current_user.is_admin %}
+      <a href="{{ url_for('admin_overview') }}" class="btn btn-warning btn-sm ml-2">Admin</a>
+    {% endif %}
+  </p>
+  <h3>Deine Trainingspläne</h3>
+  <a href="{{ url_for('create_training_plan') }}" class="btn btn-success mb-3 btn-block">Neuen Trainingsplan erstellen</a>
+  <ul class="list-group">
+    {% for plan in training_plans %}
+      <li class="list-group-item">
+        <a href="{{ url_for('training_plan_detail', training_plan_id=plan.id) }}">{{ plan.title }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+  <a href="{{ url_for('template_plans') }}" class="btn btn-info btn-block mt-3">Vorlagen ansehen</a>
+  <div class="dropdown mt-3">
+    <button class="btn btn-outline-primary btn-block dropdown-toggle" type="button" id="dashboardActionsDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      Weitere Aktionen
+    </button>
+    <div class="dropdown-menu dropdown-menu-right w-100" aria-labelledby="dashboardActionsDropdown">
+      <h6 class="dropdown-header">Datenexport</h6>
+      <a class="dropdown-item" href="{{ url_for('export_training_data') }}">Trainingsdaten als JSON exportieren</a>
+      <a class="dropdown-item" href="{{ url_for('export_training_data', format='csv') }}">Trainingsdaten als CSV exportieren</a>
+      <div class="dropdown-divider"></div>
+      <span class="dropdown-item-text text-muted small">JSON-Export unterstützt optionale ZIP-Komprimierung über <code>?zip=1</code>.</span>
     </div>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-LtrjvnR4/Jkk+1AnsuGukdxbCJO/q9OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  </body>
-</html>
+  </div>
+  {% if current_user.is_admin or current_user.is_trainer %}
+    <a href="{{ url_for('admin_template_plans') }}" class="btn btn-warning btn-block mt-3">Template Trainingspläne verwalten</a>
+  {% endif %}
+{% endblock %}

--- a/templates/edit_exercise.html
+++ b/templates/edit_exercise.html
@@ -1,27 +1,20 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Übung bearbeiten</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Übung bearbeiten</h2>
-      <form method="POST">
-        {{ form.hidden_tag() }}
-        <div class="form-group">
-          {{ form.name.label }} {{ form.name(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.description.label }} {{ form.description(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.submit(class="btn btn-primary btn-block", value="Speichern") }}
-        </div>
-      </form>
-      <a href="{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}" class="btn btn-secondary btn-block">Zurück</a>
+{% extends "base.html" %}
+
+{% block title %}Übung bearbeiten{% endblock %}
+
+{% block content %}
+  <h2>Übung bearbeiten</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.name.label }} {{ form.name(class="form-control") }}
     </div>
-  </body>
-</html>
+    <div class="form-group">
+      {{ form.description.label }} {{ form.description(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn btn-primary btn-block", value="Speichern") }}
+    </div>
+  </form>
+  <a href="{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/edit_footer_link.html
+++ b/templates/edit_footer_link.html
@@ -1,28 +1,20 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Footer Link bearbeiten</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Footer Link bearbeiten</h2>
-      <form method="POST">
-        {{ form.hidden_tag() }}
-        <div class="form-group">
-          {{ form.title.label }} {{ form.title(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.url.label }} {{ form.url(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.submit(class="btn btn-primary btn-block") }}
-        </div>
-      </form>
-      <a href="{{ url_for('admin_footer_links') }}" class="btn btn-secondary btn-block">Zurück</a>
-    </div>
-  </body>
-</html>
+{% extends "base.html" %}
 
+{% block title %}Footer Link bearbeiten{% endblock %}
+
+{% block content %}
+  <h2>Footer Link bearbeiten</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.title.label }} {{ form.title(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.url.label }} {{ form.url(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn btn-primary btn-block") }}
+    </div>
+  </form>
+  <a href="{{ url_for('admin_footer_links') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/edit_footer_page.html
+++ b/templates/edit_footer_page.html
@@ -1,28 +1,20 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Footer-Seite bearbeiten</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Footer-Seite bearbeiten</h2>
-      <form method="POST">
-        {{ form.hidden_tag() }}
-        <div class="form-group">
-          {{ form.title.label }} {{ form.title(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.content.label }} {{ form.content(class="form-control", rows=8) }}
-        </div>
-        <div class="form-group">
-          {{ form.submit(class="btn btn-primary btn-block") }}
-        </div>
-      </form>
-      <a href="{{ url_for('admin_footer_pages') }}" class="btn btn-secondary btn-block">Zurück</a>
-    </div>
-  </body>
-</html>
+{% extends "base.html" %}
 
+{% block title %}Footer-Seite bearbeiten{% endblock %}
+
+{% block content %}
+  <h2>Footer-Seite bearbeiten</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.title.label }} {{ form.title(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.content.label }} {{ form.content(class="form-control", rows=8) }}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn btn-primary btn-block") }}
+    </div>
+  </form>
+  <a href="{{ url_for('admin_footer_pages') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/edit_template_plan.html
+++ b/templates/edit_template_plan.html
@@ -1,27 +1,20 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Template Trainingsplan bearbeiten</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Template Trainingsplan bearbeiten</h2>
-      <form method="POST">
-        {{ form.hidden_tag() }}
-        <div class="form-group">
-          {{ form.title.label }} {{ form.title(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.description.label }} {{ form.description(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.submit(class="btn btn-primary btn-block") }}
-        </div>
-      </form>
-      <a href="{{ url_for('admin_template_plans') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% extends "base.html" %}
+
+{% block title %}Template Trainingsplan bearbeiten{% endblock %}
+
+{% block content %}
+  <h2>Template Trainingsplan bearbeiten</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.title.label }} {{ form.title(class="form-control") }}
     </div>
-  </body>
-</html>
+    <div class="form-group">
+      {{ form.description.label }} {{ form.description(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn btn-primary btn-block") }}
+    </div>
+  </form>
+  <a href="{{ url_for('admin_template_plans') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/exercise_detail.html
+++ b/templates/exercise_detail.html
@@ -1,244 +1,250 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Details für {{ exercise.name }}</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <style>
-      #chartContainer { margin: auto; height: 250px; }
-      @media (min-width: 768px) { #chartContainer { height: 400px; } }
-    </style>
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2 class="text-center">Verlauf für "{{ exercise.name }}"</h2>
-      {% if exercise.description %}
-        <p class="text-center text-muted">{{ exercise.description }}</p>
-      {% endif %}
-      {% if summary_metrics.total_sessions %}
-        <div class="row text-center mb-4">
-          <div class="col-sm-6 col-lg-3 mb-3">
-            <div class="card shadow-sm h-100">
-              <div class="card-body">
-                <h6 class="text-uppercase text-muted">Gesamtvolumen</h6>
-                <h4 class="mb-1">{{ summary_metrics.total_volume|round(1) }} kg</h4>
-                <div class="small text-muted">{{ summary_metrics.total_sessions }} Sätze insgesamt</div>
-                <div class="small text-muted">Gleitender Ø ({{ moving_window }}): {{ summary_metrics.recent_volume_average|round(1) }} kg</div>
-                <div class="small text-muted">Bester Satz: {{ personal_bests.max_volume.value }} kg am {{ personal_bests.max_volume.timestamp.strftime('%d.%m.%Y') }}</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-lg-3 mb-3">
-            <div class="card shadow-sm h-100">
-              <div class="card-body">
-                <h6 class="text-uppercase text-muted">Letzte Einheit</h6>
-                <h5 class="mb-1">{{ summary_metrics.latest_session.weight }} kg × {{ summary_metrics.latest_session.repetitions }}</h5>
-                <div class="small text-muted">{{ summary_metrics.latest_session.timestamp.strftime('%d.%m.%Y %H:%M') }}</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-lg-3 mb-3">
-            <div class="card shadow-sm h-100">
-              <div class="card-body">
-                <h6 class="text-uppercase text-muted">Max. Gewicht</h6>
-                <h4 class="mb-1">{{ personal_bests.max_weight.value }} kg</h4>
-                <div class="small text-muted">{{ personal_bests.max_weight.repetitions }} Wdh · {{ personal_bests.max_weight.timestamp.strftime('%d.%m.%Y') }}</div>
-                <div class="small text-muted">Volumen: {{ personal_bests.max_volume.value }} kg</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-lg-3 mb-3">
-            <div class="card shadow-sm h-100">
-              <div class="card-body">
-                <h6 class="text-uppercase text-muted">Beste 1RM (Epley)</h6>
-                <h4 class="mb-1">{{ personal_bests.max_one_rm.value|round(1) }} kg</h4>
-                <div class="small text-muted">{{ personal_bests.max_one_rm.weight }} kg × {{ personal_bests.max_one_rm.repetitions }} Wdh</div>
-                <div class="small text-muted">Gleitender Ø ({{ moving_window }}): {{ summary_metrics.recent_one_rm_average|round(1) }} kg</div>
-              </div>
-            </div>
+{% extends "base.html" %}
+
+{% block title %}Details für {{ exercise.name }}{% endblock %}
+
+{% block extra_head %}
+  <style>
+    #chartContainer {
+      margin: auto;
+      height: 250px;
+    }
+
+    @media (min-width: 768px) {
+      #chartContainer {
+        height: 400px;
+      }
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <h2 class="text-center">Verlauf für "{{ exercise.name }}"</h2>
+  {% if exercise.description %}
+    <p class="text-center text-muted">{{ exercise.description }}</p>
+  {% endif %}
+  {% if summary_metrics.total_sessions %}
+    <div class="row text-center mb-4">
+      <div class="col-sm-6 col-lg-3 mb-3">
+        <div class="card shadow-sm h-100">
+          <div class="card-body">
+            <h6 class="text-uppercase text-muted">Gesamtvolumen</h6>
+            <h4 class="mb-1">{{ summary_metrics.total_volume|round(1) }} kg</h4>
+            <div class="small text-muted">{{ summary_metrics.total_sessions }} Sätze insgesamt</div>
+            <div class="small text-muted">Gleitender Ø ({{ moving_window }}): {{ summary_metrics.recent_volume_average|round(1) }} kg</div>
+            <div class="small text-muted">Bester Satz: {{ personal_bests.max_volume.value }} kg am {{ personal_bests.max_volume.timestamp.strftime('%d.%m.%Y') }}</div>
           </div>
         </div>
-      {% else %}
-        <div class="alert alert-info">Für diese Übung wurden noch keine Trainingseinheiten erfasst.</div>
-      {% endif %}
-      <div id="chartContainer" class="mb-4">
-        <canvas id="progressChart"></canvas>
       </div>
-      <a href="{{ url_for('add_session', exercise_id=exercise.id) }}" class="btn btn-primary btn-block mb-2">Neuen Satz hinzufügen</a>
-      <h3>Letzte 15 Sätze</h3>
-      <ul class="list-group">
-        {% for session in sessions %}
-          <li class="list-group-item d-flex justify-content-between align-items-center">
-            <div>
-              <div>{{ session.timestamp.strftime('%d.%m.%Y %H:%M') }} - {{ session.weight }} kg - {{ session.repetitions }} Wiederholungen</div>
-              {% if session.perceived_exertion is not none or session.notes %}
-                <div class="mt-1 small text-muted">
-                  {% if session.perceived_exertion is not none %}
-                    <div>RPE: {{ session.perceived_exertion }}</div>
-                  {% endif %}
-                  {% if session.notes %}
-                    <div>Notizen: {{ session.notes.replace('\n', '<br>')|safe }}</div>
-                  {% endif %}
-                </div>
+      <div class="col-sm-6 col-lg-3 mb-3">
+        <div class="card shadow-sm h-100">
+          <div class="card-body">
+            <h6 class="text-uppercase text-muted">Letzte Einheit</h6>
+            <h5 class="mb-1">{{ summary_metrics.latest_session.weight }} kg × {{ summary_metrics.latest_session.repetitions }}</h5>
+            <div class="small text-muted">{{ summary_metrics.latest_session.timestamp.strftime('%d.%m.%Y %H:%M') }}</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-6 col-lg-3 mb-3">
+        <div class="card shadow-sm h-100">
+          <div class="card-body">
+            <h6 class="text-uppercase text-muted">Max. Gewicht</h6>
+            <h4 class="mb-1">{{ personal_bests.max_weight.value }} kg</h4>
+            <div class="small text-muted">{{ personal_bests.max_weight.repetitions }} Wdh · {{ personal_bests.max_weight.timestamp.strftime('%d.%m.%Y') }}</div>
+            <div class="small text-muted">Volumen: {{ personal_bests.max_volume.value }} kg</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-6 col-lg-3 mb-3">
+        <div class="card shadow-sm h-100">
+          <div class="card-body">
+            <h6 class="text-uppercase text-muted">Beste 1RM (Epley)</h6>
+            <h4 class="mb-1">{{ personal_bests.max_one_rm.value|round(1) }} kg</h4>
+            <div class="small text-muted">{{ personal_bests.max_one_rm.weight }} kg × {{ personal_bests.max_one_rm.repetitions }} Wdh</div>
+            <div class="small text-muted">Gleitender Ø ({{ moving_window }}): {{ summary_metrics.recent_one_rm_average|round(1) }} kg</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% else %}
+    <div class="alert alert-info">Für diese Übung wurden noch keine Trainingseinheiten erfasst.</div>
+  {% endif %}
+  <div id="chartContainer" class="mb-4">
+    <canvas id="progressChart"></canvas>
+  </div>
+  <a href="{{ url_for('add_session', exercise_id=exercise.id) }}" class="btn btn-primary btn-block mb-2">Neuen Satz hinzufügen</a>
+  <h3>Letzte 15 Sätze</h3>
+  <ul class="list-group">
+    {% for session in sessions %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <div>
+          <div>{{ session.timestamp.strftime('%d.%m.%Y %H:%M') }} - {{ session.weight }} kg - {{ session.repetitions }} Wiederholungen</div>
+          {% if session.perceived_exertion is not none or session.notes %}
+            <div class="mt-1 small text-muted">
+              {% if session.perceived_exertion is not none %}
+                <div>RPE: {{ session.perceived_exertion }}</div>
+              {% endif %}
+              {% if session.notes %}
+                <div>Notizen: {{ session.notes.replace('\n', '<br>')|safe }}</div>
               {% endif %}
             </div>
-            <form action="{{ url_for('delete_session', session_id=session.id) }}" method="POST" onsubmit="return confirm('Satz wirklich löschen?');">
-              {{ delete_session_form.hidden_tag() }}
-              {{ delete_session_form.submit(class="btn btn-danger btn-sm", value="×") }}
-            </form>
-          </li>
-        {% endfor %}
-      </ul>
-      <form action="{{ url_for('delete_exercise', exercise_id=exercise.id) }}" method="POST" class="mt-4" onsubmit="return confirm('Übung wirklich löschen?');">
-        {{ delete_exercise_form.hidden_tag() }}
-        {% if editable %}
-          <a href="{{ url_for('edit_exercise', exercise_id=exercise.id) }}" class="btn btn-info btn-block mb-4">Übung bearbeiten</a>
-        {% else %}
-          <div class="alert alert-warning">Diese Übung kann nicht bearbeitet werden.</div>
-        {% endif %}
-        {{ delete_exercise_form.submit(class="btn btn-danger btn-block", value='Übung löschen') }}
-      </form>
-      <a href="{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}" class="btn btn-secondary btn-block mt-2">Zurück</a>
-    </div>
-    <script>
-      const chartData = {{ chart_data|tojson }};
-      const movingWindow = {{ moving_window }};
-      const labels = chartData.labels;
-      const notes = chartData.notes;
-      const perceivedExertion = chartData.perceived_exertion;
-      const ctx = document.getElementById('progressChart').getContext('2d');
-      const progressChart = new Chart(ctx, {
-        type: 'line',
-        data: {
-          labels: labels,
-          datasets: [
-            {
-              label: 'Gewicht (kg)',
-              data: chartData.weights,
-              borderColor: 'rgba(75, 192, 192, 1)',
-              backgroundColor: 'rgba(75, 192, 192, 0.2)',
-              fill: false,
-              tension: 0.1,
-              yAxisID: 'yWeight'
-            },
-            {
-              label: 'Wiederholungen',
-              data: chartData.repetitions,
-              borderColor: 'rgba(153, 102, 255, 1)',
-              backgroundColor: 'rgba(153, 102, 255, 0.2)',
-              fill: false,
-              tension: 0.1,
-              yAxisID: 'yReps'
-            },
-            {
-              label: 'Volumen (kg)',
-              data: chartData.volume,
-              borderColor: 'rgba(255, 99, 132, 1)',
-              backgroundColor: 'rgba(255, 99, 132, 0.2)',
-              fill: false,
-              tension: 0.1,
-              yAxisID: 'yVolume'
-            },
-            {
-              label: `Volumen gleitender Ø (${movingWindow})`,
-              data: chartData.moving_avg_volume,
-              borderColor: 'rgba(194, 24, 91, 1)',
-              backgroundColor: 'rgba(194, 24, 91, 0.15)',
-              borderDash: [6, 4],
-              fill: false,
-              tension: 0.2,
-              yAxisID: 'yVolume'
-            },
-            {
-              label: '1RM (Epley)',
-              data: chartData.one_rm,
-              borderColor: 'rgba(255, 159, 64, 1)',
-              backgroundColor: 'rgba(255, 159, 64, 0.2)',
-              fill: false,
-              tension: 0.1,
-              yAxisID: 'yWeight'
-            },
-            {
-              label: `1RM gleitender Ø (${movingWindow})`,
-              data: chartData.moving_avg_one_rm,
-              borderColor: 'rgba(255, 205, 86, 1)',
-              backgroundColor: 'rgba(255, 205, 86, 0.15)',
-              borderDash: [4, 4],
-              fill: false,
-              tension: 0.2,
-              yAxisID: 'yWeight'
-            }
-          ]
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          interaction: { mode: 'index', intersect: false },
-          plugins: {
-            tooltip: {
-              callbacks: {
-                afterBody: function(context) {
-                  const index = context[0].dataIndex;
-                  const details = [];
-                  const volume = chartData.volume[index];
-                  const oneRm = chartData.one_rm[index];
-                  if (volume !== undefined) {
-                    details.push('Volumen: ' + volume + ' kg');
-                  }
-                  if (oneRm !== undefined) {
-                    details.push('1RM (Epley): ' + oneRm.toFixed(1) + ' kg');
-                  }
-                  const rpeValue = perceivedExertion[index];
-                  const noteValue = notes[index];
-                  if (rpeValue !== null && rpeValue !== undefined) {
-                    details.push('RPE: ' + rpeValue);
-                  }
-                  if (noteValue) {
-                    details.push('Notizen: ' + noteValue);
-                  }
-                  return details;
+          {% endif %}
+        </div>
+        <form action="{{ url_for('delete_session', session_id=session.id) }}" method="POST" onsubmit="return confirm('Satz wirklich löschen?');">
+          {{ delete_session_form.hidden_tag() }}
+          {{ delete_session_form.submit(class="btn btn-danger btn-sm", value="×") }}
+        </form>
+      </li>
+    {% endfor %}
+  </ul>
+  <form action="{{ url_for('delete_exercise', exercise_id=exercise.id) }}" method="POST" class="mt-4" onsubmit="return confirm('Übung wirklich löschen?');">
+    {{ delete_exercise_form.hidden_tag() }}
+    {% if editable %}
+      <a href="{{ url_for('edit_exercise', exercise_id=exercise.id) }}" class="btn btn-info btn-block mb-4">Übung bearbeiten</a>
+    {% else %}
+      <div class="alert alert-warning">Diese Übung kann nicht bearbeitet werden.</div>
+    {% endif %}
+    {{ delete_exercise_form.submit(class="btn btn-danger btn-block", value='Übung löschen') }}
+  </form>
+  <a href="{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}" class="btn btn-secondary btn-block mt-2">Zurück</a>
+{% endblock %}
+
+{% block extra_scripts %}
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script>
+    const chartData = {{ chart_data|tojson }};
+    const movingWindow = {{ moving_window }};
+    const labels = chartData.labels;
+    const notes = chartData.notes;
+    const perceivedExertion = chartData.perceived_exertion;
+    const ctx = document.getElementById('progressChart').getContext('2d');
+    const progressChart = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: labels,
+        datasets: [
+          {
+            label: 'Gewicht (kg)',
+            data: chartData.weights,
+            borderColor: 'rgba(75, 192, 192, 1)',
+            backgroundColor: 'rgba(75, 192, 192, 0.2)',
+            fill: false,
+            tension: 0.1,
+            yAxisID: 'yWeight'
+          },
+          {
+            label: 'Wiederholungen',
+            data: chartData.repetitions,
+            borderColor: 'rgba(153, 102, 255, 1)',
+            backgroundColor: 'rgba(153, 102, 255, 0.2)',
+            fill: false,
+            tension: 0.1,
+            yAxisID: 'yReps'
+          },
+          {
+            label: 'Volumen (kg)',
+            data: chartData.volume,
+            borderColor: 'rgba(255, 99, 132, 1)',
+            backgroundColor: 'rgba(255, 99, 132, 0.2)',
+            fill: false,
+            tension: 0.1,
+            yAxisID: 'yVolume'
+          },
+          {
+            label: `Volumen gleitender Ø (${movingWindow})`,
+            data: chartData.moving_avg_volume,
+            borderColor: 'rgba(194, 24, 91, 1)',
+            backgroundColor: 'rgba(194, 24, 91, 0.15)',
+            borderDash: [6, 4],
+            fill: false,
+            tension: 0.2,
+            yAxisID: 'yVolume'
+          },
+          {
+            label: '1RM (Epley)',
+            data: chartData.one_rm,
+            borderColor: 'rgba(255, 159, 64, 1)',
+            backgroundColor: 'rgba(255, 159, 64, 0.2)',
+            fill: false,
+            tension: 0.1,
+            yAxisID: 'yWeight'
+          },
+          {
+            label: `1RM gleitender Ø (${movingWindow})`,
+            data: chartData.moving_avg_one_rm,
+            borderColor: 'rgba(255, 205, 86, 1)',
+            backgroundColor: 'rgba(255, 205, 86, 0.15)',
+            borderDash: [4, 4],
+            fill: false,
+            tension: 0.2,
+            yAxisID: 'yWeight'
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: { mode: 'index', intersect: false },
+        plugins: {
+          tooltip: {
+            callbacks: {
+              afterBody: function (context) {
+                const index = context[0].dataIndex;
+                const details = [];
+                const volume = chartData.volume[index];
+                const oneRm = chartData.one_rm[index];
+                if (volume !== undefined) {
+                  details.push('Volumen: ' + volume + ' kg');
                 }
+                if (oneRm !== undefined) {
+                  details.push('1RM (Epley): ' + oneRm.toFixed(1) + ' kg');
+                }
+                const rpeValue = perceivedExertion[index];
+                const noteValue = notes[index];
+                if (rpeValue !== null && rpeValue !== undefined) {
+                  details.push('RPE: ' + rpeValue);
+                }
+                if (noteValue) {
+                  details.push('Notizen: ' + noteValue);
+                }
+                return details;
               }
             }
+          }
+        },
+        scales: {
+          x: {
+            title: { display: true, text: 'Datum und Uhrzeit' }
           },
-          scales: {
-            x: {
-              title: { display: true, text: 'Datum und Uhrzeit' }
-            },
-            yWeight: {
-              type: 'linear',
-              position: 'left',
-              title: { display: true, text: 'Gewicht / 1RM (kg)' },
-              beginAtZero: true
-            },
-            yVolume: {
-              type: 'linear',
-              position: 'right',
-              title: { display: true, text: 'Volumen (kg)' },
-              beginAtZero: true,
-              grid: { drawOnChartArea: false }
-            },
-            yReps: {
-              type: 'linear',
-              position: 'right',
-              display: false,
-              beginAtZero: true
-            }
+          yWeight: {
+            type: 'linear',
+            position: 'left',
+            title: { display: true, text: 'Gewicht / 1RM (kg)' },
+            beginAtZero: true
+          },
+          yVolume: {
+            type: 'linear',
+            position: 'right',
+            title: { display: true, text: 'Volumen (kg)' },
+            beginAtZero: true,
+            grid: { drawOnChartArea: false }
+          },
+          yReps: {
+            type: 'linear',
+            position: 'right',
+            display: false,
+            beginAtZero: true
           }
         }
-      });
-      </script>
-      <script>
-        // Stelle sicher, dass der Zurück-Button zum Trainingsplan führt
-        history.replaceState({from: 'plan'}, "", "{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}");
-        history.pushState({from: 'exercise'}, "", location.pathname + location.search);
-        window.addEventListener('popstate', function(e) {
-          if (location.pathname.startsWith('/exercise/') && e.state && e.state.from === 'exercise') {
-            location.replace("{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}");
-          }
-        });
-      </script>
-  </body>
-</html>
+      }
+    });
+  </script>
+  <script>
+    history.replaceState({ from: 'plan' }, "", "{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}");
+    history.pushState({ from: 'exercise' }, "", location.pathname + location.search);
+    window.addEventListener('popstate', function (e) {
+      if (location.pathname.startsWith('/exercise/') && e.state && e.state.from === 'exercise') {
+        location.replace("{{ url_for('training_plan_detail', training_plan_id=user_plan.id) }}");
+      }
+    });
+  </script>
+{% endblock %}

--- a/templates/footer_page.html
+++ b/templates/footer_page.html
@@ -1,18 +1,11 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>{{ page.title }}</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>{{ page.title }}</h2>
-      <div class="mt-3">
-        {{ html_content|safe }}
-      </div>
-      <a href="{{ url_for('login') }}" class="btn btn-secondary mt-4">Zurück</a>
-    </div>
-  </body>
-</html>
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }}{% endblock %}
+
+{% block content %}
+  <h2>{{ page.title }}</h2>
+  <div class="mt-3">
+    {{ html_content|safe }}
+  </div>
+  <a href="{{ url_for('login') }}" class="btn btn-secondary mt-4">Zurück</a>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,31 +1,13 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Fitness App</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <link rel="manifest" href="/static/manifest.json">
-  </head>
-  <body>
-    <div class="container mt-4 text-center">
-      <h1>Willkommen in der Fitness App</h1>
-      <p>
-        <a href="{{ url_for('login') }}" class="btn btn-primary">Login</a>
-        <a href="{{ url_for('register') }}" class="btn btn-secondary">Registrieren</a>
-      </p>
-    </div>
-    <script src="/static/js/main.js"></script>
-    <script>
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', function() {
-          navigator.serviceWorker.register('/static/sw.js').then(function(registration) {
-            console.log('ServiceWorker registration successful with scope: ', registration.scope);
-          }, function(err) {
-            console.log('ServiceWorker registration failed: ', err);
-          });
-        });
-      }
-    </script>
-  </body>
-</html>
+{% extends "base.html" %}
+
+{% block title %}Fitness App{% endblock %}
+
+{% block content %}
+  <div class="text-center">
+    <h1>Willkommen in der Fitness App</h1>
+    <p>
+      <a href="{{ url_for('login') }}" class="btn btn-primary">Login</a>
+      <a href="{{ url_for('register') }}" class="btn btn-secondary">Registrieren</a>
+    </p>
+  </div>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,36 +1,29 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Login</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Login</h2>
-      <form method="POST">
-        {{ form.hidden_tag() }}
-        <div class="form-group">
-          {{ form.username.label }} {{ form.username(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.password.label }} {{ form.password(class="form-control") }}
-        </div>
-        <div class="form-group form-check">
-          {{ form.remember(class="form-check-input") }}
-          {{ form.remember.label(class="form-check-label") }}
-        </div>
-        <div class="form-group">
-          {{ form.submit(class="btn btn-primary btn-block") }}
-        </div>
-      </form>
-      <p>Noch nicht registriert? <a href="{{ url_for('register') }}">Registrieren</a></p>
+{% extends "base.html" %}
+
+{% block title %}Login{% endblock %}
+
+{% block content %}
+  <h2>Login</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.username.label }} {{ form.username(class="form-control") }}
     </div>
-    <footer class="bg-light text-center py-2 fixed-bottom">
-      {% for page in footer_pages %}
-        <a href="{{ url_for('view_footer_page', page_id=page.id) }}" class="mx-2">{{ page.title }}</a>
-      {% endfor %}
-    </footer>
-  </body>
-</html>
+    <div class="form-group">
+      {{ form.password.label }} {{ form.password(class="form-control") }}
+    </div>
+    <div class="form-group form-check">
+      {{ form.remember(class="form-check-input") }}
+      {{ form.remember.label(class="form-check-label") }}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn btn-primary btn-block") }}
+    </div>
+  </form>
+  <p>Noch nicht registriert? <a href="{{ url_for('register') }}">Registrieren</a></p>
+  <footer class="bg-light text-center py-2 fixed-bottom">
+    {% for page in footer_pages %}
+      <a href="{{ url_for('view_footer_page', page_id=page.id) }}" class="mx-2">{{ page.title }}</a>
+    {% endfor %}
+  </footer>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,35 +1,28 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Registrieren</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Registrieren</h2>
-      <form method="POST">
-        {{ form.hidden_tag() }}
-        <div class="form-group">
-          {{ form.username.label }} {{ form.username(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.password.label }} {{ form.password(class="form-control") }}
-        </div>
-        <div class="form-group">
-          {{ form.confirm.label }} {{ form.confirm(class="form-control") }}
-        </div>
-        {% if form.recaptcha is not none %}
-          <div class="form-group">
-            {{ form.recaptcha }}
-          </div>
-        {% endif %}
-        <div class="form-group">
-          {{ form.submit(class="btn btn-primary btn-block") }}
-        </div>
-      </form>
-      <p>Bereits registriert? <a href="{{ url_for('login') }}">Login</a></p>
+{% extends "base.html" %}
+
+{% block title %}Registrieren{% endblock %}
+
+{% block content %}
+  <h2>Registrieren</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.username.label }} {{ form.username(class="form-control") }}
     </div>
-  </body>
-</html>
+    <div class="form-group">
+      {{ form.password.label }} {{ form.password(class="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ form.confirm.label }} {{ form.confirm(class="form-control") }}
+    </div>
+    {% if form.recaptcha is not none %}
+      <div class="form-group">
+        {{ form.recaptcha }}
+      </div>
+    {% endif %}
+    <div class="form-group">
+      {{ form.submit(class="btn btn-primary btn-block") }}
+    </div>
+  </form>
+  <p>Bereits registriert? <a href="{{ url_for('login') }}">Login</a></p>
+{% endblock %}

--- a/templates/template_plans.html
+++ b/templates/template_plans.html
@@ -1,38 +1,31 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Vorlagen</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>Verfügbare Template Trainingspläne</h2>
-      <table class="table table-striped">
-        <thead>
-          <tr>
-            <th>Titel</th>
-            <th>Beschreibung</th>
-            <th>Aktion</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for tpl in templates %}
-          <tr>
-            <td>{{ tpl.title }}</td>
-            <td>{{ tpl.description }}</td>
-            <td>
-              <a href="{{ url_for('view_template_plan', template_plan_id=tpl.id) }}" class="btn btn-info btn-sm">Ansehen</a>
-              <form action="{{ url_for('add_template_to_account', template_plan_id=tpl.id) }}" method="POST" style="display:inline;" onsubmit="return confirm('Diese Vorlage zu deinem Konto hinzufügen?');">
-                <button type="submit" class="btn btn-success btn-sm">Hinzufügen</button>
-              </form>
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-      <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block">Zurück</a>
-    </div>
-  </body>
-</html>
+{% extends "base.html" %}
+
+{% block title %}Vorlagen{% endblock %}
+
+{% block content %}
+  <h2>Verfügbare Template Trainingspläne</h2>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Titel</th>
+        <th>Beschreibung</th>
+        <th>Aktion</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for tpl in templates %}
+        <tr>
+          <td>{{ tpl.title }}</td>
+          <td>{{ tpl.description }}</td>
+          <td>
+            <a href="{{ url_for('view_template_plan', template_plan_id=tpl.id) }}" class="btn btn-info btn-sm">Ansehen</a>
+            <form action="{{ url_for('add_template_to_account', template_plan_id=tpl.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Diese Vorlage zu deinem Konto hinzufügen?');">
+              <button type="submit" class="btn btn-success btn-sm">Hinzufügen</button>
+            </form>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block">Zurück</a>
+{% endblock %}

--- a/templates/template_plans.html
+++ b/templates/template_plans.html
@@ -4,28 +4,30 @@
 
 {% block content %}
   <h2>Verfügbare Template Trainingspläne</h2>
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th>Titel</th>
-        <th>Beschreibung</th>
-        <th>Aktion</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for tpl in templates %}
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
         <tr>
-          <td>{{ tpl.title }}</td>
-          <td>{{ tpl.description }}</td>
-          <td>
-            <a href="{{ url_for('view_template_plan', template_plan_id=tpl.id) }}" class="btn btn-info btn-sm">Ansehen</a>
-            <form action="{{ url_for('add_template_to_account', template_plan_id=tpl.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Diese Vorlage zu deinem Konto hinzufügen?');">
-              <button type="submit" class="btn btn-success btn-sm">Hinzufügen</button>
-            </form>
-          </td>
+          <th>Titel</th>
+          <th>Beschreibung</th>
+          <th>Aktion</th>
         </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        {% for tpl in templates %}
+          <tr>
+            <td>{{ tpl.title }}</td>
+            <td>{{ tpl.description }}</td>
+            <td>
+              <a href="{{ url_for('view_template_plan', template_plan_id=tpl.id) }}" class="btn btn-info btn-sm">Ansehen</a>
+              <form action="{{ url_for('add_template_to_account', template_plan_id=tpl.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Diese Vorlage zu deinem Konto hinzufügen?');">
+                <button type="submit" class="btn btn-success btn-sm">Hinzufügen</button>
+              </form>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
   <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block">Zurück</a>
 {% endblock %}

--- a/templates/training_plan_detail.html
+++ b/templates/training_plan_detail.html
@@ -1,126 +1,124 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>{{ training_plan.title }}</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <style>
-      .session-list { font-size: 0.9rem; }
-    </style>
-  </head>
-  <body>
-    <div class="container mt-4">
-      <div class="d-flex justify-content-between align-items-center">
-        <h2>{{ training_plan.title }}</h2>
-        <form action="{{ url_for('delete_training_plan', training_plan_id=training_plan.id) }}" method="POST" onsubmit="return confirm('Trainingsplan wirklich löschen?');">
-          {{ delete_plan_form.hidden_tag() }}
-          {{ delete_plan_form.submit(class="btn btn-danger btn-sm") }}
-        </form>
-      </div>
-      <p>{{ training_plan.description }}</p>
-      <a href="{{ url_for('add_exercise_to_plan', training_plan_id=training_plan.id) }}" class="btn btn-success mb-3 btn-block">Übung hinzufügen</a>
-      {% if exercise_overview %}
-        <h3>Übungsstatistiken</h3>
-        <div class="table-responsive mb-4">
-          <table class="table table-sm table-striped">
-            <thead>
-              <tr>
-                <th>Übung</th>
-                <th class="text-center">Sätze</th>
-                <th>Letzte Einheit</th>
-                <th>Gesamtvolumen</th>
-                <th>Max. Gewicht</th>
-                <th>Beste 1RM (Epley)</th>
-                <th>Ø Volumen ({{ exercise_overview[0].moving_window }}er Ø)</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for item in exercise_overview %}
-                {% set summary = item.summary %}
-                {% set personal_bests = item.personal_bests %}
-                <tr>
-                  <td>
-                    <strong>{{ item.exercise.name }}</strong>
-                    {% if item.exercise.description %}
-                      <div class="small text-muted">{{ item.exercise.description }}</div>
-                    {% endif %}
-                  </td>
-                  <td class="text-center">{{ summary.total_sessions }}</td>
-                  <td>
-                    {% if summary.latest_session %}
-                      {{ summary.latest_session.timestamp.strftime('%d.%m.%Y') }}<br>
-                      <span class="small text-muted">{{ summary.latest_session.weight }} kg × {{ summary.latest_session.repetitions }}</span>
-                    {% else %}
-                      <span class="text-muted">–</span>
-                    {% endif %}
-                  </td>
-                  <td>
-                    {% if summary.total_sessions %}
-                      {{ summary.total_volume|round(1) }} kg
-                    {% else %}
-                      <span class="text-muted">–</span>
-                    {% endif %}
-                  </td>
-                  <td>
-                    {% if personal_bests.max_weight %}
-                      {{ personal_bests.max_weight.value }} kg
-                      <div class="small text-muted">{{ personal_bests.max_weight.repetitions }} Wdh</div>
-                    {% else %}
-                      <span class="text-muted">–</span>
-                    {% endif %}
-                  </td>
-                  <td>
-                    {% if personal_bests.max_one_rm %}
-                      {{ personal_bests.max_one_rm.value|round(1) }} kg
-                      <div class="small text-muted">{{ personal_bests.max_one_rm.weight }} kg × {{ personal_bests.max_one_rm.repetitions }}</div>
-                    {% else %}
-                      <span class="text-muted">–</span>
-                    {% endif %}
-                  </td>
-                  <td>
-                    {% if summary.total_sessions %}
-                      {{ summary.recent_volume_average|round(1) }} kg
-                    {% else %}
-                      <span class="text-muted">–</span>
-                    {% endif %}
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-        <h3>Übungen</h3>
-        <ul class="list-group">
+{% extends "base.html" %}
+
+{% block title %}{{ training_plan.title }}{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .session-list {
+      font-size: 0.9rem;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <div class="d-flex justify-content-between align-items-center">
+    <h2>{{ training_plan.title }}</h2>
+    <form action="{{ url_for('delete_training_plan', training_plan_id=training_plan.id) }}" method="POST" onsubmit="return confirm('Trainingsplan wirklich löschen?');">
+      {{ delete_plan_form.hidden_tag() }}
+      {{ delete_plan_form.submit(class="btn btn-danger btn-sm") }}
+    </form>
+  </div>
+  <p>{{ training_plan.description }}</p>
+  <a href="{{ url_for('add_exercise_to_plan', training_plan_id=training_plan.id) }}" class="btn btn-success mb-3 btn-block">Übung hinzufügen</a>
+  {% if exercise_overview %}
+    <h3>Übungsstatistiken</h3>
+    <div class="table-responsive mb-4">
+      <table class="table table-sm table-striped">
+        <thead>
+          <tr>
+            <th>Übung</th>
+            <th class="text-center">Sätze</th>
+            <th>Letzte Einheit</th>
+            <th>Gesamtvolumen</th>
+            <th>Max. Gewicht</th>
+            <th>Beste 1RM (Epley)</th>
+            <th>Ø Volumen ({{ exercise_overview[0].moving_window }}er Ø)</th>
+          </tr>
+        </thead>
+        <tbody>
           {% for item in exercise_overview %}
-            <li class="list-group-item">
-              <div class="d-flex justify-content-between align-items-center">
-                <div>
-                  <strong>{{ item.exercise.name }}</strong>
-                  {% if item.exercise.description %}
-                    <p class="mb-0 small text-muted">{{ item.exercise.description }}</p>
-                  {% endif %}
-                </div>
-                <div>
-                  <a href="{{ url_for('exercise_detail', exercise_id=item.exercise.id) }}" class="btn btn-info btn-sm mr-1">Details</a>
-                </div>
-              </div>
-              <div class="session-list mt-2">
-                {% for session in item.recent_sessions %}
-                  <div>
-                    {{ session.timestamp.strftime('%d.%m.%Y %H:%M') }} - {{ session.weight }} kg - {{ session.repetitions }} Wiederholungen
-                  </div>
+            {% set summary = item.summary %}
+            {% set personal_bests = item.personal_bests %}
+            <tr>
+              <td>
+                <strong>{{ item.exercise.name }}</strong>
+                {% if item.exercise.description %}
+                  <div class="small text-muted">{{ item.exercise.description }}</div>
+                {% endif %}
+              </td>
+              <td class="text-center">{{ summary.total_sessions }}</td>
+              <td>
+                {% if summary.latest_session %}
+                  {{ summary.latest_session.timestamp.strftime('%d.%m.%Y') }}<br>
+                  <span class="small text-muted">{{ summary.latest_session.weight }} kg × {{ summary.latest_session.repetitions }}</span>
                 {% else %}
-                  <div class="text-muted">Noch keine Einheiten erfasst.</div>
-                {% endfor %}
-              </div>
-            </li>
+                  <span class="text-muted">–</span>
+                {% endif %}
+              </td>
+              <td>
+                {% if summary.total_sessions %}
+                  {{ summary.total_volume|round(1) }} kg
+                {% else %}
+                  <span class="text-muted">–</span>
+                {% endif %}
+              </td>
+              <td>
+                {% if personal_bests.max_weight %}
+                  {{ personal_bests.max_weight.value }} kg
+                  <div class="small text-muted">{{ personal_bests.max_weight.repetitions }} Wdh</div>
+                {% else %}
+                  <span class="text-muted">–</span>
+                {% endif %}
+              </td>
+              <td>
+                {% if personal_bests.max_one_rm %}
+                  {{ personal_bests.max_one_rm.value|round(1) }} kg
+                  <div class="small text-muted">{{ personal_bests.max_one_rm.weight }} kg × {{ personal_bests.max_one_rm.repetitions }}</div>
+                {% else %}
+                  <span class="text-muted">–</span>
+                {% endif %}
+              </td>
+              <td>
+                {% if summary.total_sessions %}
+                  {{ summary.recent_volume_average|round(1) }} kg
+                {% else %}
+                  <span class="text-muted">–</span>
+                {% endif %}
+              </td>
+            </tr>
           {% endfor %}
-        </ul>
-      {% else %}
-        <div class="alert alert-info">Füge deinem Trainingsplan eine Übung hinzu, um Auswertungen zu sehen.</div>
-      {% endif %}
-      <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block mt-3">Zurück</a>
+        </tbody>
+      </table>
     </div>
-  </body>
-</html>
+    <h3>Übungen</h3>
+    <ul class="list-group">
+      {% for item in exercise_overview %}
+        <li class="list-group-item">
+          <div class="d-flex justify-content-between align-items-center">
+            <div>
+              <strong>{{ item.exercise.name }}</strong>
+              {% if item.exercise.description %}
+                <p class="mb-0 small text-muted">{{ item.exercise.description }}</p>
+              {% endif %}
+            </div>
+            <div>
+              <a href="{{ url_for('exercise_detail', exercise_id=item.exercise.id) }}" class="btn btn-info btn-sm mr-1">Details</a>
+            </div>
+          </div>
+          <div class="session-list mt-2">
+            {% for session in item.recent_sessions %}
+              <div>
+                {{ session.timestamp.strftime('%d.%m.%Y %H:%M') }} - {{ session.weight }} kg - {{ session.repetitions }} Wiederholungen
+              </div>
+            {% else %}
+              <div class="text-muted">Noch keine Einheiten erfasst.</div>
+            {% endfor %}
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <div class="alert alert-info">Füge deinem Trainingsplan eine Übung hinzu, um Auswertungen zu sehen.</div>
+  {% endif %}
+  <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block mt-3">Zurück</a>
+{% endblock %}

--- a/templates/view_template_plan.html
+++ b/templates/view_template_plan.html
@@ -1,29 +1,22 @@
-<!doctype html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Vorlage: {{ template_plan.title }}</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  </head>
-  <body>
-    <div class="container mt-4">
-      <h2>{{ template_plan.title }}</h2>
-      <p>{{ template_plan.description }}</p>
-      <h4>Enthaltene Übungen</h4>
-      <ul class="list-group mb-4">
-        {% for exercise in template_plan.exercises %}
-          <li class="list-group-item">
-            <strong>{{ exercise.name }}</strong>
-            {% if exercise.description %}
-              <p class="mb-0 small text-muted">{{ exercise.description }}</p>
-            {% endif %}
-          </li>
-        {% else %}
-          <li class="list-group-item">Keine Übungen vorhanden.</li>
-        {% endfor %}
-      </ul>
-      <a href="{{ url_for('template_plans') }}" class="btn btn-secondary btn-block">Zurück zu Vorlagen</a>
-    </div>
-  </body>
-</html>
+{% extends "base.html" %}
+
+{% block title %}Vorlage: {{ template_plan.title }}{% endblock %}
+
+{% block content %}
+  <h2>{{ template_plan.title }}</h2>
+  <p>{{ template_plan.description }}</p>
+  <h4>Enthaltene Übungen</h4>
+  <ul class="list-group mb-4">
+    {% for exercise in template_plan.exercises %}
+      <li class="list-group-item">
+        <strong>{{ exercise.name }}</strong>
+        {% if exercise.description %}
+          <p class="mb-0 small text-muted">{{ exercise.description }}</p>
+        {% endif %}
+      </li>
+    {% else %}
+      <li class="list-group-item">Keine Übungen vorhanden.</li>
+    {% endfor %}
+  </ul>
+  <a href="{{ url_for('template_plans') }}" class="btn btn-secondary btn-block">Zurück zu Vorlagen</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a shared `base.html` template with Bootstrap head assets, navigation, and service-worker registration
- update all templates to extend the base, moving their page content into blocks and preserving page-specific head/script sections

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e11b338b888322a7fb96e42e678276