### PR TITLE
Fix dashboard export dropdown toggle

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,0 +1,48 @@
+(function () {
+  function setupDashboardDropdown() {
+    var toggle = document.getElementById('dashboardActionsDropdown');
+    if (!toggle) {
+      return;
+    }
+
+    var menu = toggle.nextElementSibling;
+    if (!menu || !menu.classList.contains('dropdown-menu')) {
+      return;
+    }
+
+    function closeMenu() {
+      menu.classList.remove('show');
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+
+    toggle.addEventListener('click', function (event) {
+      event.preventDefault();
+      event.stopPropagation();
+      var isOpen = menu.classList.contains('show');
+      if (isOpen) {
+        closeMenu();
+      } else {
+        menu.classList.add('show');
+        toggle.setAttribute('aria-expanded', 'true');
+      }
+    });
+
+    document.addEventListener('click', function (event) {
+      if (!menu.contains(event.target) && !toggle.contains(event.target)) {
+        closeMenu();
+      }
+    });
+
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape') {
+        closeMenu();
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupDashboardDropdown);
+  } else {
+    setupDashboardDropdown();
+  }
+})();

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -44,5 +44,6 @@
     </div>
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-LtrjvnR4/Jkk+1AnsuGukdxbCJO/q9OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the dashboard export dropdown works even without Bootstrap's JavaScript by adding a lightweight local toggle script
- include the new script from the dashboard template so the menu can be opened and closed reliably

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e12ec8ca208322b04c34b611051204