### PR TITLE
Add collapsible exercise sessions to training plan detail

### DIFF
--- a/templates/training_plan_detail.html
+++ b/templates/training_plan_detail.html
@@ -91,8 +91,9 @@
           </table>
         </div>
         <h3>Übungen</h3>
-        <ul class="list-group">
+        <ul class="list-group" id="exercise-list">
           {% for item in exercise_overview %}
+            {% set collapse_id = 'sessions-' ~ loop.index %}
             <li class="list-group-item">
               <div class="d-flex justify-content-between align-items-center">
                 <div>
@@ -101,11 +102,14 @@
                     <p class="mb-0 small text-muted">{{ item.exercise.description }}</p>
                   {% endif %}
                 </div>
-                <div>
-                  <a href="{{ url_for('exercise_detail', exercise_id=item.exercise.id) }}" class="btn btn-info btn-sm mr-1">Details</a>
+                <div class="d-flex align-items-center">
+                  <button class="btn btn-outline-secondary btn-sm mr-2" type="button" data-toggle="collapse" data-target="#{{ collapse_id }}" aria-expanded="false" aria-controls="{{ collapse_id }}">
+                    Einheiten anzeigen
+                  </button>
+                  <a href="{{ url_for('exercise_detail', exercise_id=item.exercise.id) }}" class="btn btn-info btn-sm">Details</a>
                 </div>
               </div>
-              <div class="session-list mt-2">
+              <div id="{{ collapse_id }}" class="session-list mt-2 collapse" data-parent="#exercise-list">
                 {% for session in item.recent_sessions %}
                   <div>
                     {{ session.timestamp.strftime('%d.%m.%Y %H:%M') }} - {{ session.weight }} kg - {{ session.repetitions }} Wiederholungen
@@ -122,5 +126,30 @@
       {% endif %}
       <a href="{{ url_for('dashboard') }}" class="btn btn-secondary btn-block mt-3">Zurück</a>
     </div>
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        var toggles = document.querySelectorAll('[data-toggle="collapse"]');
+        toggles.forEach(function(toggle) {
+          toggle.textContent = 'Einheiten anzeigen';
+          var targetSelector = toggle.getAttribute('data-target');
+          if (!targetSelector) {
+            return;
+          }
+          var target = document.querySelector(targetSelector);
+          if (!target) {
+            return;
+          }
+          target.addEventListener('show.bs.collapse', function() {
+            toggle.textContent = 'Einheiten verbergen';
+          });
+          target.addEventListener('hide.bs.collapse', function() {
+            toggle.textContent = 'Einheiten anzeigen';
+          });
+        });
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add collapsible sections for exercise sessions on the training plan detail page to keep long plans tidy
- include Bootstrap collapse dependencies and toggle button text updates for a better UX

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e150ed05f883229934958d41d9ed28