### PR TITLE
Make exercise statistics table collapsible on training plan detail

### DIFF
--- a/templates/training_plan_detail.html
+++ b/templates/training_plan_detail.html
@@ -22,74 +22,85 @@
     <p>{{ training_plan.description }}</p>
     <a href="{{ url_for('add_exercise_to_plan', training_plan_id=training_plan.id) }}" class="btn btn-success mb-3 btn-block">Übung hinzufügen</a>
     {% if exercise_overview %}
-      <h3>Übungsstatistiken</h3>
-      <div class="table-responsive mb-4">
-        <table class="table table-sm table-striped">
-          <thead>
-            <tr>
-              <th>Übung</th>
-              <th class="text-center">Sätze</th>
-              <th>Letzte Einheit</th>
-              <th>Gesamtvolumen</th>
-              <th>Max. Gewicht</th>
-              <th>Beste 1RM (Epley)</th>
-              <th>Ø Volumen ({{ exercise_overview[0].moving_window }}er Ø)</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for item in exercise_overview %}
-              {% set summary = item.summary %}
-              {% set personal_bests = item.personal_bests %}
+      <button
+        class="btn btn-outline-secondary btn-block text-left mb-3"
+        type="button"
+        data-toggle="collapse"
+        data-target="#exerciseStatsCollapse"
+        aria-expanded="true"
+        aria-controls="exerciseStatsCollapse"
+      >
+        Übungsstatistiken
+      </button>
+      <div id="exerciseStatsCollapse" class="collapse show">
+        <div class="table-responsive mb-4">
+          <table class="table table-sm table-striped">
+            <thead>
               <tr>
-                <td>
-                  <strong>{{ item.exercise.name }}</strong>
-                  {% if item.exercise.description %}
-                    <div class="small text-muted">{{ item.exercise.description }}</div>
-                  {% endif %}
-                </td>
-                <td class="text-center">{{ summary.total_sessions }}</td>
-                <td>
-                  {% if summary.latest_session %}
-                    {{ summary.latest_session.timestamp.strftime('%d.%m.%Y') }}<br>
-                    <span class="small text-muted">{{ summary.latest_session.weight }} kg × {{ summary.latest_session.repetitions }}</span>
-                  {% else %}
-                    <span class="text-muted">–</span>
-                  {% endif %}
-                </td>
-                <td>
-                  {% if summary.total_sessions %}
-                    {{ summary.total_volume|round(1) }} kg
-                  {% else %}
-                    <span class="text-muted">–</span>
-                  {% endif %}
-                </td>
-                <td>
-                  {% if personal_bests.max_weight %}
-                    {{ personal_bests.max_weight.value }} kg
-                    <div class="small text-muted">{{ personal_bests.max_weight.repetitions }} Wdh</div>
-                  {% else %}
-                    <span class="text-muted">–</span>
-                  {% endif %}
-                </td>
-                <td>
-                  {% if personal_bests.max_one_rm %}
-                    {{ personal_bests.max_one_rm.value|round(1) }} kg
-                    <div class="small text-muted">{{ personal_bests.max_one_rm.weight }} kg × {{ personal_bests.max_one_rm.repetitions }}</div>
-                  {% else %}
-                    <span class="text-muted">–</span>
-                  {% endif %}
-                </td>
-                <td>
-                  {% if summary.total_sessions %}
-                    {{ summary.recent_volume_average|round(1) }} kg
-                  {% else %}
-                    <span class="text-muted">–</span>
-                  {% endif %}
-                </td>
+                <th>Übung</th>
+                <th class="text-center">Sätze</th>
+                <th>Letzte Einheit</th>
+                <th>Gesamtvolumen</th>
+                <th>Max. Gewicht</th>
+                <th>Beste 1RM (Epley)</th>
+                <th>Ø Volumen ({{ exercise_overview[0].moving_window }}er Ø)</th>
               </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {% for item in exercise_overview %}
+                {% set summary = item.summary %}
+                {% set personal_bests = item.personal_bests %}
+                <tr>
+                  <td>
+                    <strong>{{ item.exercise.name }}</strong>
+                    {% if item.exercise.description %}
+                      <div class="small text-muted">{{ item.exercise.description }}</div>
+                    {% endif %}
+                  </td>
+                  <td class="text-center">{{ summary.total_sessions }}</td>
+                  <td>
+                    {% if summary.latest_session %}
+                      {{ summary.latest_session.timestamp.strftime('%d.%m.%Y') }}<br>
+                      <span class="small text-muted">{{ summary.latest_session.weight }} kg × {{ summary.latest_session.repetitions }}</span>
+                    {% else %}
+                      <span class="text-muted">–</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if summary.total_sessions %}
+                      {{ summary.total_volume|round(1) }} kg
+                    {% else %}
+                      <span class="text-muted">–</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if personal_bests.max_weight %}
+                      {{ personal_bests.max_weight.value }} kg
+                      <div class="small text-muted">{{ personal_bests.max_weight.repetitions }} Wdh</div>
+                    {% else %}
+                      <span class="text-muted">–</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if personal_bests.max_one_rm %}
+                      {{ personal_bests.max_one_rm.value|round(1) }} kg
+                      <div class="small text-muted">{{ personal_bests.max_one_rm.weight }} kg × {{ personal_bests.max_one_rm.repetitions }}</div>
+                    {% else %}
+                      <span class="text-muted">–</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if summary.total_sessions %}
+                      {{ summary.recent_volume_average|round(1) }} kg
+                    {% else %}
+                      <span class="text-muted">–</span>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
       </div>
       <h3>Übungen</h3>
       <ul class="list-group">


### PR DESCRIPTION
## Summary
- replace the exercise statistics heading with a collapse toggle button
- wrap the statistics table in a collapse container that is expanded by default

## Testing
- no tests were run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e179e3eb648322bd331537070c01ba