### PR TITLE
Clarify RPE terminology in training session views

### DIFF
--- a/app.py
+++ b/app.py
@@ -198,7 +198,7 @@ class ExerciseSessionForm(FlaskForm):
     repetitions = IntegerField('Wiederholungen', validators=[DataRequired()], render_kw={"onfocus": "this.select()"})
     weight = IntegerField('Gewicht (kg)', validators=[InputRequired()], render_kw={"step": "1", "onfocus": "this.select()"})
     perceived_exertion = IntegerField(
-        'RPE (optional)',
+        'Wahrgenommene Anstrengung (RPE 1-10, optional)',
         validators=[Optional(), NumberRange(min=1, max=10)],
         render_kw={"min": "1", "max": "10", "onfocus": "this.select()"}
     )

--- a/templates/exercise_detail.html
+++ b/templates/exercise_detail.html
@@ -82,7 +82,7 @@
             {% if session.perceived_exertion is not none or session.notes %}
               <div class="mt-1 small text-muted">
                 {% if session.perceived_exertion is not none %}
-                  <div>RPE: {{ session.perceived_exertion }}</div>
+                  <div>Wahrgenommene Anstrengung (RPE): {{ session.perceived_exertion }}</div>
                 {% endif %}
                 {% if session.notes %}
                   <div>Notizen: {{ session.notes.replace('\n', '<br>')|safe }}</div>
@@ -203,7 +203,7 @@
                 const rpeValue = perceivedExertion[index];
                 const noteValue = notes[index];
                 if (rpeValue !== null && rpeValue !== undefined) {
-                  details.push('RPE: ' + rpeValue);
+                  details.push('Wahrgenommene Anstrengung (RPE): ' + rpeValue);
                 }
                 if (noteValue) {
                   details.push('Notizen: ' + noteValue);


### PR DESCRIPTION
## Summary
- clarify the perceived exertion label in the session form to spell out the RPE scale
- update the exercise detail view and chart tooltip to use the more descriptive wording

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e19d241fac83228e6c1fb51b4d075b