### PR TITLE
Add admin controls for footer links

### DIFF
--- a/templates/admin_overview.html
+++ b/templates/admin_overview.html
@@ -6,6 +6,7 @@
   <div class="container">
     <h2 class="mb-4">Admin – Benutzerübersicht</h2>
     <a href="{{ url_for('admin_footer_pages') }}" class="btn btn-info mb-3 btn-block">Footer-Seiten verwalten</a>
+    <a href="{{ url_for('admin_footer_links') }}" class="btn btn-info mb-3 btn-block">Footer-Links verwalten</a>
 
     <table class="table table-striped">
       <thead>

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,11 +14,16 @@
     <footer class="bg-light border-top py-3 mt-auto">
       <div class="container">
         <nav class="d-flex flex-wrap justify-content-center">
-          {% for page in footer_pages %}
-            <a href="{{ url_for('view_footer_page', page_id=page.id) }}" class="text-muted small mx-2 my-1">{{ page.title }}</a>
+          {% if footer_pages or footer_links %}
+            {% for page in footer_pages %}
+              <a href="{{ url_for('view_footer_page', page_id=page.id) }}" class="text-muted small mx-2 my-1">{{ page.title }}</a>
+            {% endfor %}
+            {% for link in footer_links %}
+              <a href="{{ link.url }}" class="text-muted small mx-2 my-1">{{ link.title }}</a>
+            {% endfor %}
           {% else %}
             <span class="text-muted small">&copy; {{ config.get('APP_NAME', 'Gewichts-Tracker') }}</span>
-          {% endfor %}
+          {% endif %}
         </nav>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- add a database model and forms so admins can manage simple footer links
- expose CRUD routes and navigation to maintain footer links from the admin area
- render configured footer links next to footer pages in the site footer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e213a9086883229cd5e3a9eaacb605