### PR TITLE
Add migration utility for new exercise ownership fields

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Simple database migration utility for Gewichts-Tracker.
+
+This script ensures that legacy installations receive the ownership columns
+introduced in newer releases and attempts to backfill the necessary data so
+existing users retain access to their exercises and logged sessions.
+
+Example usage::
+
+    python migrate.py
+    python migrate.py --database-uri sqlite:////path/to/fitness.db
+    python migrate.py --dry-run --verbose
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from contextlib import contextmanager
+from typing import Iterable, Set
+
+from sqlalchemy import inspect, text
+
+from app import app, db, Exercise, ExerciseSession
+
+LOGGER = logging.getLogger(__name__)
+
+
+@contextmanager
+def application_context(database_uri: str | None):
+    """Provide an application context with an optional database override."""
+
+    if database_uri:
+        app.config["SQLALCHEMY_DATABASE_URI"] = database_uri
+    with app.app_context():
+        yield
+
+
+def add_column_if_missing(table_name: str, column_name: str, ddl: str) -> bool:
+    """Add a column to *table_name* when it does not yet exist."""
+
+    engine = db.engine
+    inspector = inspect(engine)
+    columns = {col["name"] for col in inspector.get_columns(table_name)}
+    if column_name in columns:
+        LOGGER.debug("Column %s.%s already present", table_name, column_name)
+        return False
+
+    LOGGER.info("Adding column %s.%s", table_name, column_name)
+    with engine.begin() as conn:
+        conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {ddl}"))
+    return True
+
+
+def _plan_owner_ids(exercise) -> Set[int]:
+    return {plan.user_id for plan in exercise.training_plans if plan.user_id is not None}
+
+
+def backfill_exercise_owners() -> int:
+    """Populate exercise.user_id where it can be determined unambiguously."""
+
+    updates = 0
+    for exercise in Exercise.query.all():
+        owners = _plan_owner_ids(exercise)
+        if len(owners) == 1:
+            owner_id = next(iter(owners))
+            if exercise.user_id != owner_id:
+                LOGGER.debug("Assigning exercise %s to user %s", exercise.id, owner_id)
+                exercise.user_id = owner_id
+                updates += 1
+        elif not owners:
+            LOGGER.debug("Exercise %s has no plans attached; skipping", exercise.id)
+        else:
+            LOGGER.warning(
+                "Exercise %s is linked to plans from multiple users (%s); manual review recommended",
+                exercise.id,
+                sorted(owners),
+            )
+    return updates
+
+
+def backfill_session_owners() -> int:
+    """Populate exercise_session.user_id where possible."""
+
+    updates = 0
+    for session in ExerciseSession.query.all():
+        if session.user_id is not None:
+            continue
+        exercise = session.exercise
+        if exercise is None:
+            LOGGER.warning("Session %s references missing exercise; skipping", session.id)
+            continue
+        owners = _plan_owner_ids(exercise)
+        chosen_user = None
+        if len(owners) == 1:
+            chosen_user = next(iter(owners))
+        elif exercise.user_id is not None:
+            chosen_user = exercise.user_id
+        if chosen_user is not None:
+            LOGGER.debug("Assigning session %s to user %s", session.id, chosen_user)
+            session.user_id = chosen_user
+            updates += 1
+        else:
+            LOGGER.warning(
+                "Could not determine owner for session %s (exercise %s); leaving unset",
+                session.id,
+                exercise.id if exercise else "?",
+            )
+    return updates
+
+
+def run_migration(database_uri: str | None, dry_run: bool) -> None:
+    with application_context(database_uri):
+        LOGGER.info("Running migrations")
+        altered = False
+        altered |= add_column_if_missing("exercise", "user_id", "INTEGER")
+        altered |= add_column_if_missing("exercise_session", "user_id", "INTEGER")
+
+        # Backfill ownership information so that historical data stays accessible.
+        exercise_updates = backfill_exercise_owners()
+        session_updates = backfill_session_owners()
+
+        LOGGER.info(
+            "Backfill summary: %s exercise ownership assignments, %s session ownership assignments",
+            exercise_updates,
+            session_updates,
+        )
+
+        if dry_run:
+            db.session.rollback()
+            LOGGER.info("Dry run complete; no changes committed")
+        else:
+            db.session.commit()
+            LOGGER.info(
+                "Migration finished successfully%s",
+                " (schema altered)" if altered else "",
+            )
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run database migrations for Gewichts-Tracker")
+    parser.add_argument(
+        "--database-uri",
+        dest="database_uri",
+        help="SQLAlchemy database URI. Defaults to the application's configured database.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Perform the migration without committing data changes.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging output.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+    run_migration(args.database_uri, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -35,7 +35,7 @@ def client():
         db.session.add(plan)
         db.session.flush()
 
-        exercise = Exercise(name='Kniebeuge', description='Langhantel')
+        exercise = Exercise(name='Kniebeuge', description='Langhantel', user_id=user.id)
         db.session.add(exercise)
         db.session.flush()
         plan.exercises.append(exercise)
@@ -47,6 +47,7 @@ def client():
             weight=100,
             notes='Saubere Technik',
             perceived_exertion=8,
+            user_id=user.id,
         )
         db.session.add(session)
         db.session.commit()

--- a/tests/test_session_privacy.py
+++ b/tests/test_session_privacy.py
@@ -1,0 +1,81 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app import app, db, User, TrainingPlan, Exercise, ExerciseSession, generate_password_hash
+
+
+@pytest.fixture
+def client_with_shared_exercise():
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI='sqlite:///:memory:',
+        WTF_CSRF_ENABLED=False,
+    )
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        user_a = User(username='alice', password=generate_password_hash('secret-a'))
+        user_b = User(username='bob', password=generate_password_hash('secret-b'))
+        db.session.add_all([user_a, user_b])
+        db.session.commit()
+
+        plan_a = TrainingPlan(title='Plan A', description='', user_id=user_a.id)
+        plan_b = TrainingPlan(title='Plan B', description='', user_id=user_b.id)
+        db.session.add_all([plan_a, plan_b])
+        db.session.flush()
+
+        shared_exercise = Exercise(name='Bankdrücken', description='Flachbank')
+        db.session.add(shared_exercise)
+        db.session.flush()
+
+        plan_a.exercises.append(shared_exercise)
+        plan_b.exercises.append(shared_exercise)
+        db.session.flush()
+
+        session_a = ExerciseSession(
+            exercise_id=shared_exercise.id,
+            repetitions=8,
+            weight=80,
+            user_id=user_a.id,
+        )
+        session_b = ExerciseSession(
+            exercise_id=shared_exercise.id,
+            repetitions=5,
+            weight=100,
+            user_id=user_b.id,
+        )
+        db.session.add_all([session_a, session_b])
+        db.session.commit()
+
+        exercise_id = shared_exercise.id
+
+    with app.test_client() as client:
+        yield client, exercise_id
+
+
+def test_users_only_see_their_own_sessions(client_with_shared_exercise):
+    client, exercise_id = client_with_shared_exercise
+
+    login_a = client.post('/api/login', json={'username': 'alice', 'password': 'secret-a'})
+    assert login_a.status_code == 200
+
+    response_a = client.get(f'/api/exercises/{exercise_id}/sessions')
+    assert response_a.status_code == 200
+    data_a = response_a.get_json()
+    assert [entry['weight'] for entry in data_a] == [80]
+
+    client.post('/api/logout')
+
+    login_b = client.post('/api/login', json={'username': 'bob', 'password': 'secret-b'})
+    assert login_b.status_code == 200
+
+    response_b = client.get(f'/api/exercises/{exercise_id}/sessions')
+    assert response_b.status_code == 200
+    data_b = response_b.get_json()
+    assert [entry['weight'] for entry in data_b] == [100]


### PR DESCRIPTION
## Summary
- add a standalone migration script that creates the new ownership columns and backfills exercises and sessions where possible
- support overriding the database URI, dry-run execution, and verbose logging to help administrators upgrade safely

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e25f592b98832286ba245d63194bd1